### PR TITLE
fix: resolve script bugs breaking non-interactive setup

### DIFF
--- a/chat_app/compose-wrapper.sh
+++ b/chat_app/compose-wrapper.sh
@@ -17,6 +17,9 @@ envsubst '$BASE_DOMAIN' < ./synapse/wellknownclient.conf.template > ./synapse/we
 envsubst '$BASE_DOMAIN' < ./synapse/wellknownserver.conf.template > ./synapse/wellknownserver.conf
 envsubst '$BASE_DOMAIN' < ./chat/config.json.template > ./chat/config.json
 
+# Ensure homeserver.yaml has the generated content (avoids empty file issue with overlapping volume mounts)
+cp ./synapse/homeserver-postgres.yaml ./synapse/homeserver.yaml
+
 # Check if file was created
 if [ ! -f "./synapse/.env" ]; then
     echo "Failed to create configuration file"
@@ -49,4 +52,4 @@ if [ "$ACTION" != "up" ]; then
   exit 0
 fi
 
-sudo docker exec -it chat_app-synapse-1 update-ca-certificates
+sudo docker exec chat_app-synapse-1 update-ca-certificates

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -11,6 +11,7 @@ REPOS=(
     ["twake_db"]="${BASE_DIR}/twake_db"
     ["twake_auth"]="${BASE_DIR}/twake_auth"
     ["cozy_stack"]="${BASE_DIR}/cozy_stack"
+    ["linshare_app"]="${BASE_DIR}/linshare_app"
     ["onlyoffice_app"]="${BASE_DIR}/onlyoffice_app"
     ["meet_app"]="${BASE_DIR}/meet_app"
     ["calendar_app"]="${BASE_DIR}/calendar_app"
@@ -19,8 +20,8 @@ REPOS=(
 )
 
 # Order of operations
-START_ORDER=("twake_db" "twake_auth" "cozy_stack" "onlyoffice_app" "meet_app" "calendar_app" "chat_app" "tmail_app")
-STOP_ORDER=("tmail_app" "chat_app" "calendar_app" "meet_app" "onlyoffice_app" "cozy_stack" "twake_auth" "twake_db")
+START_ORDER=("twake_db" "twake_auth" "cozy_stack" "linshare_app" "onlyoffice_app" "meet_app" "calendar_app" "chat_app" "tmail_app")
+STOP_ORDER=("tmail_app" "chat_app" "calendar_app" "meet_app" "onlyoffice_app" "linshare_app" "cozy_stack" "twake_auth" "twake_db")
 
 # Dependencies: containers that must be healthy before starting a repo
 declare -A REPO_DEPS


### PR DESCRIPTION
## Summary
- Remove `-it` flag from `docker exec` in `chat_app/compose-wrapper.sh` (fails without TTY in non-interactive mode)
- Copy `homeserver-postgres.yaml` to `homeserver.yaml` before `docker compose up` to fix empty file issue with overlapping Docker volume mounts (Synapse restart loop)
- Add `linshare_app` to `wrapper.sh` REPOS, START_ORDER and STOP_ORDER (documented in README but missing from orchestration)

## Test plan
- [ ] Run `./wrapper.sh up -d` end-to-end without a TTY — chat_app and tmail_app should both start
- [ ] Verify Synapse container reaches healthy state without manual intervention
- [ ] Verify LinShare containers are started when running full stack

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)