### PR TITLE
feat: add macOS development environment support

### DIFF
--- a/calendar_app/compose-wrapper.sh
+++ b/calendar_app/compose-wrapper.sh
@@ -3,6 +3,11 @@
 
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 
 # Load environment variables
@@ -45,7 +50,7 @@ fi
 
 
 # Pass all arguments to docker compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"
 
 # 🚨 Everything below is UP-only
 if [ "$ACTION" != "up" ]; then
@@ -59,14 +64,14 @@ CA_FILE="/usr/local/share/ca-certificates/root-ca.crt"
 echo "⏳ Waiting for $CONTAINER to start..."
 
 # Wait indefinitely until container is running
-until [ "$(sudo docker inspect -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null || echo "missing")" = "running" ]; do
+until [ "$(${SUDO} docker inspect -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null || echo "missing")" = "running" ]; do
   sleep 7
 done
 
 echo "✔ $CONTAINER is running, importing CA..."
 
 # Idempotent import: only adds if alias does not exist
-sudo docker exec "$CONTAINER" bash -c "
+${SUDO} docker exec "$CONTAINER" bash -c "
   keytool -list -keystore \$JAVA_HOME/lib/security/cacerts \
     -storepass changeit -alias $CA_ALIAS >/dev/null 2>&1 || \
   keytool -importcert -trustcacerts \
@@ -78,4 +83,4 @@ sudo docker exec "$CONTAINER" bash -c "
 "
 
 echo "▶ Restarting $CONTAINER to apply changes..."
-sudo docker restart "$CONTAINER"
+${SUDO} docker restart "$CONTAINER"

--- a/chat_app/compose-wrapper.sh
+++ b/chat_app/compose-wrapper.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 
 # Load environment variables
@@ -42,11 +47,11 @@ fi
 fi
 
 # Pass all arguments to docker compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"
 
 # 🚨 Everything below is UP-only
 if [ "$ACTION" != "up" ]; then
   exit 0
 fi
 
-sudo docker exec -it chat_app-synapse-1 update-ca-certificates
+${SUDO} docker exec -it chat_app-synapse-1 update-ca-certificates

--- a/cozy_stack/compose-wrapper.sh
+++ b/cozy_stack/compose-wrapper.sh
@@ -2,6 +2,11 @@
 # compose-wrapper.sh
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 # Load environment variables
 set -a
@@ -21,4 +26,4 @@ fi
 
 
 # Pass all arguments to docker compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"

--- a/linshare_app/compose-wrapper.sh
+++ b/linshare_app/compose-wrapper.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 
 set -a
@@ -23,7 +28,7 @@ if [ "$ACTION" = "up" ]; then
 fi
 
 # Always call compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"
 
 # 🚨 Everything below is UP-only
 if [ "$ACTION" != "up" ]; then
@@ -34,7 +39,7 @@ fi
 echo "⏳ Waiting for backend container to become healthy..."
 
 while true; do
-  STATUS=$(sudo docker inspect \
+  STATUS=$(${SUDO} docker inspect \
     --format='{{if .State.Health}}{{.State.Health.Status}}{{end}}' \
     "$BACKEND_CONTAINER" 2>/dev/null || echo "starting")
 

--- a/meet_app/compose-wrapper.sh
+++ b/meet_app/compose-wrapper.sh
@@ -3,6 +3,11 @@
 
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 
 # Load environment variables
@@ -23,4 +28,4 @@ fi
 fi
 
 # Pass all arguments to docker compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"

--- a/tmail_app/compose-wrapper.sh
+++ b/tmail_app/compose-wrapper.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 
 # Load environment variables
@@ -46,4 +51,4 @@ fi
 fi
 
 # Pass all arguments to docker compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"

--- a/twake_auth/compose-wrapper.sh
+++ b/twake_auth/compose-wrapper.sh
@@ -2,6 +2,11 @@
 # compose-wrapper.sh
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 
 # Load environment variables
@@ -28,11 +33,11 @@ if [ "$ACTION" = "up" ]; then
 fi
 
 
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"
 
 if [ "${CERTS_REGENERATED:-}" = "true" ]; then
   echo "Certs were regenerated, restarting reverse-proxy..."
-  sudo docker compose --env-file ../.env restart reverse-proxy
+  ${SUDO} docker compose --env-file ../.env restart reverse-proxy
 fi
 
 if [ "$ACTION" != "up" ]; then
@@ -43,7 +48,7 @@ echo "⏳ Waiting for LemonLDAP to be healthy (timeout 5 min)..."
 ELAPSED=0
 MAX_WAIT=300
 while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
-  STATUS=$(sudo docker inspect \
+  STATUS=$(${SUDO} docker inspect \
     --format='{{if .State.Health}}{{.State.Health.Status}}{{end}}' \
     "lemonldap-ng" 2>/dev/null || echo "starting")
 
@@ -74,4 +79,4 @@ if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
   exit 1
 fi
 
-sudo docker exec lemonldap-ng bash -c "/usr/share/lemonldap-ng/bin/rotateOidcKeys" || true
+${SUDO} docker exec lemonldap-ng bash -c "/usr/share/lemonldap-ng/bin/rotateOidcKeys" || true

--- a/twake_db/compose-wrapper.sh
+++ b/twake_db/compose-wrapper.sh
@@ -2,6 +2,11 @@
 # compose-wrapper.sh
 set -e
 
+# Detect whether sudo is needed for docker (on macOS Docker Desktop, it's not)
+if [ -z "$SUDO" ]; then
+  if docker info &>/dev/null; then SUDO=""; else SUDO="sudo"; fi
+fi
+
 ACTION="$1"
 # Load environment variables
 set -a
@@ -22,4 +27,4 @@ fi
 
 
 # Pass all arguments to docker compose
-sudo docker compose --env-file ../.env "$@"
+${SUDO} docker compose --env-file ../.env "$@"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,5 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
+
+# macOS ships bash 3.x which doesn't support associative arrays (declare -A).
+# Re-exec under zsh (available by default on macOS) if needed.
+if [ -z "$ZSH_VERSION" ] && [ -z "$BASH_VERSION" -o "${BASH_VERSINFO:-0}" -lt 4 ] 2>/dev/null; then
+    if command -v zsh >/dev/null 2>&1; then
+        exec zsh "$0" "$@"
+    else
+        echo "❌ This script requires bash 4+ or zsh. Please install one of them."
+        exit 1
+    fi
+fi
+
+# ----------------------------
+# Detect whether sudo is needed for docker
+# ----------------------------
+if docker info &>/dev/null; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+export SUDO
 
 # ----------------------------
 # Configuration: paths to repos
@@ -29,15 +50,17 @@ REPO_DEPS=(
     ["tmail_app"]="lemonldap-ng"
 )
 
+SCRIPT_NAME="${0##*/}"
+
 show_help() {
-    echo "Usage: $0 <up|down> [repo] [service] [docker-compose options]"
+    echo "Usage: $SCRIPT_NAME <up|down> [repo] [service] [docker-compose options]"
     echo
     echo "Examples:"
-    echo "  $0 up -d                        Start all repos in order"
-    echo "  $0 up twake_db                  Start only the twake_db repo"
-    echo "  $0 up twake_auth lemonldap      Start only the lemonldap service in twake_auth"
-    echo "  $0 down                         Stop all repos in reverse order"
-    echo "  $0 down cozy_stack              Stop only cozy_stack"
+    echo "  $SCRIPT_NAME up -d                        Start all repos in order"
+    echo "  $SCRIPT_NAME up twake_db                  Start only the twake_db repo"
+    echo "  $SCRIPT_NAME up twake_auth lemonldap      Start only the lemonldap service in twake_auth"
+    echo "  $SCRIPT_NAME down                         Stop all repos in reverse order"
+    echo "  $SCRIPT_NAME down cozy_stack              Stop only cozy_stack"
 }
 
 # ----------------------------
@@ -46,14 +69,16 @@ show_help() {
 wait_for_repo_health() {
     echo "⏳ Waiting for all containers in repo '$1' to be healthy..."
 
-    containers=$(sudo docker compose --env-file ../.env ps -q)
-    if [[ -z "$containers" ]]; then
+    local containers_raw
+    containers_raw=$($SUDO docker compose --env-file ../.env ps -q)
+    if [[ -z "$containers_raw" ]]; then
         echo "⚠️ No containers found for $1"
         return
     fi
 
-    for c in $containers; do
-        name=$(sudo docker inspect --format '{{.Name}}' "$c" | cut -d/ -f2)
+    echo "$containers_raw" | while read -r c; do
+        [[ -z "$c" ]] && continue
+        name=$($SUDO docker inspect --format '{{.Name}}' "$c" | cut -d/ -f2)
 
         # 👉 Skip patcher container
         if [[ "$name" == patcher-* ]]; then
@@ -62,9 +87,9 @@ wait_for_repo_health() {
         fi
 
         # Check if container has healthcheck
-        status=$(sudo docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$c")
+        health_status=$($SUDO docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$c")
 
-        if [[ -z "$status" ]]; then
+        if [[ -z "$health_status" ]]; then
             echo "ℹ️ Container '$name' has no healthcheck, skipping..."
             continue
         fi
@@ -72,11 +97,11 @@ wait_for_repo_health() {
         echo "⏳ Waiting for container '$name'..."
         local attempt=0
         local max_attempts=40
-        until [[ "$(sudo docker inspect -f '{{.State.Health.Status}}' "$c")" == "healthy" ]]; do
+        until [[ "$($SUDO docker inspect -f '{{.State.Health.Status}}' "$c")" == "healthy" ]]; do
             attempt=$((attempt + 1))
             if [[ $attempt -ge $max_attempts ]]; then
                 echo "❌ Timeout waiting for '$name' to become healthy"
-                sudo docker logs "$c" --tail 20 2>&1 || true
+                $SUDO docker logs "$c" --tail 20 2>&1 || true
                 exit 1
             fi
             sleep 3
@@ -96,11 +121,11 @@ check_deps() {
     fi
 
     for dep in $deps; do
-        local status
-        status=$(sudo docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$dep" 2>/dev/null || true)
+        local health_status
+        health_status=$($SUDO docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$dep" 2>/dev/null || true)
 
-        if [[ "$status" != "healthy" ]]; then
-            echo "❌ Dependency '$dep' is not healthy (status: ${status:-not found}). Cannot start '$repo'."
+        if [[ "$health_status" != "healthy" ]]; then
+            echo "❌ Dependency '$dep' is not healthy (status: ${health_status:-not found}). Cannot start '$repo'."
             exit 1
         fi
         echo "✅ Dependency '$dep' is healthy"
@@ -140,9 +165,9 @@ run_repo() {
       fi
     else
       if [[ -n "$service" ]]; then
-        sudo docker compose --env-file ../.env "$action" "${options[@]}" "$service"
+        $SUDO docker compose --env-file ../.env "$action" "${options[@]}" "$service"
       else
-        sudo docker compose --env-file ../.env "$action" "${options[@]}"
+        $SUDO docker compose --env-file ../.env "$action" "${options[@]}"
       fi
     fi
 


### PR DESCRIPTION
## Summary
- Auto-detect bash < 4 and re-exec under zsh on macOS (bash 3.2 lacks `declare -A`)
- Auto-detect whether `sudo` is needed for docker commands (Docker Desktop vs Linux)
- Rename reserved zsh variable `status` to `health_status` in `wrapper.sh`
- Fix word splitting for `docker compose ps -q` output using `while read` (zsh doesn't split on newlines by default)
- Fix `$0` display in help output under zsh (captures `SCRIPT_NAME` before function definitions)
- Apply `$SUDO` detection to all 8 `compose-wrapper.sh` files

## Test plan
- [ ] Run `./wrapper.sh --help` on macOS (bash 3.2) — should auto-switch to zsh and display correct script name
- [ ] Run `./wrapper.sh up -d` on macOS Docker Desktop — no sudo prompts
- [ ] Run `./wrapper.sh up -d` on Linux with rootful docker — sudo used automatically
- [ ] Run individual `cd twake_db && ./compose-wrapper.sh up -d` on macOS — SUDO detection works standalone

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)