### PR TITLE
fix: gate confidential OIDC clients on LemonLDAP-NG readiness

### DIFF
--- a/twake_auth/docker-compose.yml
+++ b/twake_auth/docker-compose.yml
@@ -22,11 +22,13 @@ services:
     extra_hosts:
       - "oauthcallback.${BASE_DOMAIN}:172.27.0.100"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/"]
-      interval: 15s
-      timeout: 10s
-      retries: 5
-      start_period: 120s
+      test:
+        - CMD-SHELL
+        - curl -fs -H "Host: auth.${BASE_DOMAIN}" http://localhost/.well-known/openid-configuration | grep -q jwks_uri
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
 
     networks:
       - twake-network

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -22,11 +22,22 @@ REPOS=(
 START_ORDER=("twake_db" "twake_auth" "cozy_stack" "onlyoffice_app" "meet_app" "calendar_app" "chat_app" "tmail_app")
 STOP_ORDER=("tmail_app" "chat_app" "calendar_app" "meet_app" "onlyoffice_app" "cozy_stack" "twake_auth" "twake_db")
 
-# Dependencies: containers that must be healthy before starting a repo
+# Dependencies: containers that must be healthy before starting a repo.
+# Apps gated on lemonldap-ng:
+#   - chat_app: Synapse loads OIDC discovery (.well-known) at boot and refuses
+#     to start if the IdP is unreachable.
+#   - cozy_stack: confidential client (IDCOZY) with disable_password_authentication=true,
+#     so OIDC is the only login path.
+#   - meet_app: confidential client (visio) — exchanges code with client_secret server-side.
+#   - tmail_app, calendar_app: public clients with lazy introspection, gated as a
+#     precaution so the first login is never racing the IdP startup.
 declare -A REPO_DEPS
 REPO_DEPS=(
     ["chat_app"]="lemonldap-ng"
+    ["cozy_stack"]="lemonldap-ng"
+    ["meet_app"]="lemonldap-ng"
     ["tmail_app"]="lemonldap-ng"
+    ["calendar_app"]="lemonldap-ng"
 )
 
 show_help() {


### PR DESCRIPTION
## Summary

Two issues were causing brittle cold-starts around SSO:

1. **Healthcheck on `lemonldap-ng` was too permissive.** It only ran `curl -f http://localhost/`, which returns 200 from the portal nginx well before the OIDC layer is wired. Apps gated on it could see "healthy" and immediately fail OIDC discovery.
2. **Only `chat_app` and `tmail_app` waited for the IdP.** Apps that act as **confidential** OIDC clients (Cozy = `IDCOZY`, Meet = `visio`) — i.e. the ones that exchange the auth code with `client_secret` server-side — could start before LemonLDAP-NG was reachable, causing the very first login to fail.

### Changes

- **`twake_auth/docker-compose.yml`** — healthcheck now hits `/.well-known/openid-configuration` with the right `Host` header and asserts the JSON contains `jwks_uri`. Probe cadence tightened (10s/30 retries/30s start period) so dependents unblock faster.
- **`wrapper.sh`** — `REPO_DEPS` extended to also gate `cozy_stack`, `meet_app`, plus `tmail_app` and `calendar_app` as a precaution (their backends introspect lazily, but the first hit shouldn't race the IdP startup either). `linshare_app` remains ungated since it is a public PKCE client whose backend bootstrap (`provider.sh`) only talks to LinShare itself.

### Rationale per app

| App | Client type | Why gated |
|---|---|---|
| chat_app (matrix1) | public | Synapse reads `.well-known` at boot, **crashes** otherwise |
| cozy_stack (IDCOZY) | confidential | `disable_password_authentication: true` — OIDC is the only login |
| meet_app (visio) | confidential | Code↔token exchange uses `client_secret` server-side |
| tmail_app (james) | public | Precaution on James introspection |
| calendar_app (openpaas) | public | Precaution on tcalendar-side-service introspection |
| linshare_app | public | Lazy validation only, no boot-time IdP traffic |

## Test plan

- [ ] `./wrapper.sh down` then `./wrapper.sh up -d` from a cold state — verify `lemonldap-ng` reaches `healthy` and Synapse no longer races the IdP.
- [ ] Confirm the new healthcheck logs `jwks_uri` matching: `docker inspect --format '{{json .State.Health}}' lemonldap-ng`.
- [ ] Log into Cozy, Meet, TMail, Calendar, Chat and LinShare to confirm each OIDC flow still works.
- [ ] Stop `lemonldap-ng` and bring up `meet_app` alone — `wrapper.sh` should refuse with the existing dependency check.