### PR TITLE
fix lemonldap healthcheck single quote missing

### DIFF
--- a/twake_auth/docker-compose.yml
+++ b/twake_auth/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - curl -fs -H "Host: auth.${BASE_DOMAIN}" http://localhost/.well-known/openid-configuration | grep -q jwks_uri
+        - 'curl -fs -H "Host: auth.${BASE_DOMAIN}" http://localhost/.well-known/openid-configuration | grep -q jwks_uri'
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
the yaml parser sees the second item not as a string because of the : of the Host field, added single quotes to allow it to be parsed as a string