### PR TITLE
feat(rabbitmq): declare auth and b2b topic exchanges at boot

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 BASE_DOMAIN=twake.local
 LDAP_BASE_DN=dc=twake,dc=local
 MAIL_DOMAIN=twake.local
+RABBITMQ_DECLARE_EXCHANGES=auth,b2b

--- a/twake_db/docker-compose.yml
+++ b/twake_db/docker-compose.yml
@@ -142,6 +142,7 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
+      RABBITMQ_DECLARE_EXCHANGES: "${RABBITMQ_DECLARE_EXCHANGES}"
     labels:
       - "traefik.enable=false"  
     entrypoint: ["/bin/bash", "/etc/rabbitmq/rabbitmq-init.sh"]  

--- a/twake_db/rabbitmq/entrypoint.sh
+++ b/twake_db/rabbitmq/entrypoint.sh
@@ -16,25 +16,27 @@ rabbitmqctl add_vhost tmail || true
 rabbitmqctl set_permissions -p tmail guest ".*" ".*" ".*"
 rabbitmqctl set_user_tags guest administrator
 
-# Wait for the management HTTP API (rabbitmqadmin uses it)
-for _ in $(seq 1 30); do
-    if rabbitmqadmin list users >/dev/null 2>&1; then
-        break
-    fi
-    echo "Waiting for RabbitMQ management API..."
-    sleep 2
-done
+# Declare topic exchanges listed in RABBITMQ_DECLARE_EXCHANGES (comma-separated).
+# Used for exchanges that downstream services expect to pre-exist instead of
+# declaring themselves. Idempotent: re-running with matching params is a no-op.
+if [ -n "${RABBITMQ_DECLARE_EXCHANGES:-}" ]; then
+    # rabbitmqadmin needs the management HTTP API
+    for _ in $(seq 1 30); do
+        if rabbitmqadmin list users >/dev/null 2>&1; then
+            break
+        fi
+        echo "Waiting for RabbitMQ management API..."
+        sleep 2
+    done
 
-# Declare topic exchanges that cozy-stack expects to pre-exist
-# (its rabbitmq config sets declare_exchange: false). These carry the
-# B2B contact sync events emitted by ldap-rest:
-#   - auth: routing key user.created
-#   - b2b:  routing key domain.user.deleted
-# Idempotent: re-running with matching params is a no-op.
-for exchange in auth b2b; do
-    rabbitmqadmin declare exchange \
-        name="${exchange}" type=topic durable=true auto_delete=false internal=false
-done
+    IFS=',' read -ra EXCHANGES <<< "$RABBITMQ_DECLARE_EXCHANGES"
+    for exchange in "${EXCHANGES[@]}"; do
+        exchange="$(echo -n "$exchange" | tr -d '[:space:]')"
+        [ -z "$exchange" ] && continue
+        rabbitmqadmin declare exchange \
+            name="$exchange" type=topic durable=true auto_delete=false internal=false
+    done
+fi
 
 # Stop the detached instance and run in foreground
 rabbitmqctl stop

--- a/twake_db/rabbitmq/entrypoint.sh
+++ b/twake_db/rabbitmq/entrypoint.sh
@@ -16,6 +16,26 @@ rabbitmqctl add_vhost tmail || true
 rabbitmqctl set_permissions -p tmail guest ".*" ".*" ".*"
 rabbitmqctl set_user_tags guest administrator
 
+# Wait for the management HTTP API (rabbitmqadmin uses it)
+for _ in $(seq 1 30); do
+    if rabbitmqadmin list users >/dev/null 2>&1; then
+        break
+    fi
+    echo "Waiting for RabbitMQ management API..."
+    sleep 2
+done
+
+# Declare topic exchanges that cozy-stack expects to pre-exist
+# (its rabbitmq config sets declare_exchange: false). These carry the
+# B2B contact sync events emitted by ldap-rest:
+#   - auth: routing key user.created
+#   - b2b:  routing key domain.user.deleted
+# Idempotent: re-running with matching params is a no-op.
+for exchange in auth b2b; do
+    rabbitmqadmin declare exchange \
+        name="${exchange}" type=topic durable=true auto_delete=false internal=false
+done
+
 # Stop the detached instance and run in foreground
 rabbitmqctl stop
 exec rabbitmq-server


### PR DESCRIPTION
## Summary

Cozy-stack's RabbitMQ integration expects the `auth` and `b2b` topic exchanges to already exist on the broker: its config sets `declare_exchange: false` for both, so it only declares its own queues and bindings on top of them. The init script in this repo doesn't currently create those exchanges, which means cozy-stack's consumer setup fails and any publisher hitting the broker before cozy-stack starts is rejected.

This PR adds the missing declarations to the RabbitMQ container's init script, right after the existing vhost and permission setup. Both exchanges are declared as durable topic exchanges on the default vhost, and the call is idempotent so restarts are safe.