### PR TITLE
docs: add scim-import script and how-to for bulk user provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ calendar_app/frontend/account/openpaas.js
 calendar_app/frontend/calendar/openpaas.js
 calendar_app/frontend/contacts/openpaas.js
 calendar_app/frontend/env.js
+scripts/users.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ calendar_app/frontend/account/openpaas.js
 calendar_app/frontend/calendar/openpaas.js
 calendar_app/frontend/contacts/openpaas.js
 calendar_app/frontend/env.js
-scripts/users.json

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,47 @@
+# scripts
+
+## `scim-import-users.sh` — bulk-import users via SCIM
+
+The full Twake provisioning pipeline (LDAP entry, cozy instance, RabbitMQ event for cozy-stack) hangs off a single SCIM `POST /scim/v2/Users` call against the `ldap-rest` service. This script reads a JSON file describing one or more users and fires that call for each entry, so a deployment can be seeded — or an external IDM can drive batch imports — without writing any glue.
+
+### Why not just `cozy-stack instances add`?
+
+`cozy-stack instances add` only creates the cozy instance. SCIM creation is the one path that also produces the LDAP entry and emits the `auth/user.created` event the rest of the stack listens for. Going through SCIM keeps LDAP, cozy-stack, and any other consumer (org contact sync, …) in sync.
+
+### Prerequisites
+
+- A reachable `ldap-rest` service (deployed by `twake_auth/docker-compose.yml`)
+- `jq` and `curl` on the host running the script
+- The repo's `.env` populated — the script reads `LDAP_REST_ADMIN_TOKEN` and `BASE_DOMAIN` from it
+
+### Usage
+
+```bash
+cp scripts/users.example.json scripts/users.json   # then edit
+scripts/scim-import-users.sh scripts/users.json
+```
+
+`--dry-run` prints the SCIM body for each entry without sending anything — useful for sanity-checking your input file before hitting the live endpoint.
+
+By default the script targets `https://ldap-rest.${BASE_DOMAIN}`. To point it at a different deployment (e.g. a remote staging environment) without touching `.env`:
+
+```bash
+LDAP_REST_HOST=https://ldap-rest.staging.example.org scripts/scim-import-users.sh users.json
+```
+
+### Input format
+
+Each entry in the JSON array can be either:
+
+- a **shorthand** with the common keys (`userName`, `givenName`, `familyName`, `email`, `active`), plus any extra top-level SCIM attributes (`displayName`, `phoneNumbers`, `title`, custom extension URNs, …) which get merged onto the synthesized body, or
+- a **full SCIM User** (anything with a `schemas` field), passed through verbatim.
+
+See `scripts/users.example.json` for a worked example covering both modes. `userName` is the only field that is always required — it becomes the cozy instance subdomain (`<userName>.${BASE_DOMAIN}`).
+
+### What you should see after a successful run
+
+- `cozy-stack instances ls` lists a new instance per imported user, status `onboarded`
+- `cozy-stack apps ls --domain <user>.${BASE_DOMAIN}` shows the apps from `DM_COZY_APPS`
+- The `stack.user.created` queue on RabbitMQ shows zero pending messages and a live consumer; `auth.dlq` does not grow
+
+If `auth/user.created` lands in the dead-letter queue, the message detail in `cozyt`'s logs explains which field cozy-stack rejected — typically a configuration mismatch (context name, missing settings) rather than a script bug.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,10 +4,6 @@
 
 The full Twake provisioning pipeline (LDAP entry, cozy instance, RabbitMQ event for cozy-stack) hangs off a single SCIM `POST /scim/v2/Users` call against the `ldap-rest` service. This script reads a JSON file describing one or more users and fires that call for each entry, so a deployment can be seeded — or an external IDM can drive batch imports — without writing any glue.
 
-### Why not just `cozy-stack instances add`?
-
-`cozy-stack instances add` only creates the cozy instance. SCIM creation is the one path that also produces the LDAP entry and emits the `auth/user.created` event the rest of the stack listens for. Going through SCIM keeps LDAP, cozy-stack, and any other consumer (org contact sync, …) in sync.
-
 ### Prerequisites
 
 - A reachable `ldap-rest` service (deployed by `twake_auth/docker-compose.yml`)
@@ -38,10 +34,31 @@ Each entry in the JSON array can be either:
 
 See `scripts/users.example.json` for a worked example covering both modes. `userName` is the only field that is always required — it becomes the cozy instance subdomain (`<userName>.${BASE_DOMAIN}`).
 
-### What you should see after a successful run
+### Verifying a run
 
-- `cozy-stack instances ls` lists a new instance per imported user, status `onboarded`
-- `cozy-stack apps ls --domain <user>.${BASE_DOMAIN}` shows the apps from `DM_COZY_APPS`
-- The `stack.user.created` queue on RabbitMQ shows zero pending messages and a live consumer; `auth.dlq` does not grow
+A successful import is observable from the running stack — no extra tooling needed.
 
-If `auth/user.created` lands in the dead-letter queue, the message detail in `cozyt`'s logs explains which field cozy-stack rejected — typically a configuration mismatch (context name, missing settings) rather than a script bug.
+Cozy instances list (each imported user should appear, status `onboarded`):
+
+```bash
+docker exec cozyt cozy-stack instances ls
+```
+
+Apps installed on a given instance (matches `DM_COZY_APPS` from `twake_auth/docker-compose.yml`):
+
+```bash
+docker exec cozyt cozy-stack apps ls --domain <user>.${BASE_DOMAIN}
+```
+
+RabbitMQ — the cozy-stack consumer queue should drain to zero with a live consumer; the dead-letter queue should stay empty:
+
+```bash
+docker exec rabbitmq rabbitmqadmin list queues name messages consumers \
+  | grep -E 'stack\.user\.created|auth\.dlq'
+```
+
+If `auth/user.created` lands in the dead-letter queue, `cozyt`'s logs identify which field cozy-stack rejected — typically a configuration mismatch (context name, missing settings) rather than a script bug:
+
+```bash
+docker logs cozyt --since 5m 2>&1 | grep -i 'user.created'
+```

--- a/scripts/scim-import-users.sh
+++ b/scripts/scim-import-users.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Import users into LDAP via the ldap-rest SCIM 2.0 endpoint.
+#
+# Reads a JSON array from the file you pass as the first argument and POSTs
+# each entry to /scim/v2/Users. The cozyProvision plugin picks up the SCIM
+# create hook, provisions the cozy instance, then publishes auth/user.created
+# on RabbitMQ for cozy-stack to consume.
+#
+# Usage:
+#   scripts/scim-import-users.sh <path/to/users.json> [--dry-run]
+#
+# Each entry in the JSON array can be either:
+#   - a full SCIM User object (with `schemas`), passed through verbatim, or
+#   - a shorthand: { "userName", "givenName", "familyName", "email", "active" }
+#     plus any extra top-level fields (displayName, title, phoneNumbers, …)
+#     which get merged onto the synthesized SCIM body.
+#
+# Environment overrides:
+#   ENV_FILE         — alternate .env path (default: <repo>/.env)
+#   LDAP_REST_HOST   — alternate ldap-rest URL (default: https://ldap-rest.${BASE_DOMAIN})
+#
+# See scripts/users.example.json for a worked example.
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+
+DRY_RUN=0
+INPUT=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    -*)        echo "ERR: unknown option: $arg" >&2; usage >&2; exit 2 ;;
+    *)
+      [[ -n "$INPUT" ]] && { echo "ERR: only one input file expected" >&2; usage >&2; exit 2; }
+      INPUT="$arg" ;;
+  esac
+done
+
+if [[ -z "$INPUT" ]]; then
+  echo "ERR: missing input file" >&2
+  usage >&2
+  exit 2
+fi
+
+[[ -f "$ENV_FILE" ]] || { echo "ERR: .env not found at $ENV_FILE" >&2; exit 1; }
+[[ -f "$INPUT" ]]    || { echo "ERR: input file not found: $INPUT" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERR: jq is required" >&2; exit 1; }
+
+# shellcheck disable=SC1090
+set -a; source "$ENV_FILE"; set +a
+: "${LDAP_REST_ADMIN_TOKEN:?missing in .env}"
+: "${BASE_DOMAIN:?missing in .env}"
+
+HOST="${LDAP_REST_HOST:-https://ldap-rest.${BASE_DOMAIN}}"
+
+count=$(jq 'length' "$INPUT")
+echo "→ Importing $count user(s) from $INPUT"
+echo "  target: $HOST/scim/v2/Users"
+[[ $DRY_RUN -eq 1 ]] && echo "  (dry-run: no requests will be sent)"
+echo
+
+ok=0; fail=0
+for i in $(seq 0 $((count - 1))); do
+  # Build the SCIM body. Three modes, in priority order:
+  #   1. Entry already has `schemas` -> pass through verbatim.
+  #   2. Otherwise, expand the shorthand keys (userName/givenName/familyName/
+  #      email/active) into a SCIM body, then merge any extra top-level fields
+  #      from the entry on top (displayName, title, phoneNumbers, externalId,
+  #      preferredLanguage, custom extension URNs, ...). The user's explicit
+  #      `name` / `emails` override the synthesized ones if both are present.
+  body=$(jq -c --arg idx "$i" '
+    .[($idx | tonumber)] as $e |
+    if ($e | has("schemas")) then $e
+    else
+      ({
+        schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        userName: $e.userName,
+        name: { givenName: ($e.givenName // ""), familyName: ($e.familyName // "") },
+        emails: (if $e.email then [{ value: $e.email, primary: true }] else [] end),
+        active: ($e.active // true)
+      }) as $base |
+      ($e | del(.userName, .givenName, .familyName, .email, .active)) as $extra |
+      $base + $extra
+    end
+  ' "$INPUT")
+
+  uname=$(jq -r '.userName' <<<"$body")
+  printf "  %-24s ... " "$uname"
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "(dry-run)"
+    jq . <<<"$body" | sed 's/^/      /'
+    continue
+  fi
+
+  tmp=$(mktemp)
+  http=$(curl -k -sS -o "$tmp" -w "%{http_code}" \
+    -X POST "$HOST/scim/v2/Users" \
+    -H "Authorization: Bearer $LDAP_REST_ADMIN_TOKEN" \
+    -H "Content-Type: application/scim+json" \
+    -d "$body" || echo "000")
+
+  if [[ "$http" =~ ^2 ]]; then
+    echo "OK ($http)"
+    ok=$((ok+1))
+  else
+    echo "FAIL ($http)"
+    sed 's/^/      /' "$tmp"; echo
+    fail=$((fail+1))
+  fi
+  rm -f "$tmp"
+done
+
+echo
+if [[ $DRY_RUN -eq 0 ]]; then
+  echo "Done: $ok created, $fail failed"
+  [[ $fail -eq 0 ]]
+fi

--- a/scripts/users.example.json
+++ b/scripts/users.example.json
@@ -1,0 +1,27 @@
+[
+  {
+    "userName": "alice",
+    "givenName": "Alice",
+    "familyName": "Doe",
+    "email": "alice@example.org"
+  },
+  {
+    "userName": "bob",
+    "givenName": "Bob",
+    "familyName": "Smith",
+    "email": "bob@example.org",
+    "displayName": "Bob S.",
+    "title": "Engineer",
+    "preferredLanguage": "fr",
+    "phoneNumbers": [{ "value": "+33600000000", "primary": true }]
+  },
+  {
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    "userName": "carol",
+    "name": { "givenName": "Carol", "familyName": "White" },
+    "emails": [
+      { "value": "carol@example.org", "primary": true }
+    ],
+    "active": true
+  }
+]


### PR DESCRIPTION
## Why

The full provisioning pipeline (LDAP entry, cozy instance, `auth/user.created` event) hangs off a single SCIM call against `ldap-rest`. That makes SCIM the natural seam for seeding a deployment or driving batch imports — but nothing in the repo says so today.

`cozy-stack instances add` is the obvious-looking shortcut and a trap: it only creates the cozy half. Going through SCIM is what keeps LDAP, cozy-stack, and downstream consumers in lockstep.

## What

A small bash helper that reads a JSON array of users and fires one SCIM `POST` per entry, plus a worked example file and a short README explaining when to reach for it.