### PR TITLE
chore: use upstream yadd/ldap-rest:latest image

### DIFF
--- a/twake_auth/docker-compose.yml
+++ b/twake_auth/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - twake-network
 
   ldap-rest:
-    image: kferjani/ldap-rest:0.3.4-poc-oidc-id
+    image: yadd/ldap-rest:latest
     container_name: ldap-rest
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

- Point the `ldap-rest` service at `yadd/ldap-rest:latest` instead of a personal fork tag.