### PR TITLE
chore: bump cozy-stack to 1.6.50-rc1

### DIFF
--- a/cozy_stack/docker-compose.yml
+++ b/cozy_stack/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cozy-stack:
-    image: cozy/cozy-stack:1.6.44
+    image: cozy/cozy-stack:1.6.50-rc1
     platform: linux/amd64
     container_name: cozyt
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Bump the `cozy-stack` image tag from `1.6.44` to `1.6.50-rc1`.