### PR TITLE
fix: synapse init only chowned media_store, leaving homeserver.yaml unreadable

### DIFF
--- a/chat_app/docker-compose.yaml
+++ b/chat_app/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: busybox
     volumes:
       - ./synapse:/data
-    command: sh -c "chown -R 991:991 /data/media_store && chmod -R u+rwX /data/media_store"
+    command: sh -c "chown -R 991:991 /data && chmod -R u+rwX /data"
     restart: "no"
     networks:
       - twake-network


### PR DESCRIPTION
## Summary

- The matrixdotorg/synapse image drops privileges to uid 991 at startup regardless of the compose `user:` directive, so anything in `/data` it needs to read has to be owned by that uid.
- The init step only adjusted `/data/media_store`, so the bind-mounted `homeserver.yaml` (owned by whoever ran the wrapper on the host) caused synapse to crash on boot with `PermissionError` and the dependent containers stayed unhealthy.
- Widening the chown to all of `/data` fixes startup on a fresh checkout without changing what synapse itself does at runtime.