### PR TITLE
docs: operator runbook, scim slug check, wrapper precheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Deployment Instructions](#deployment-instructions)
 - [Test Credentials](#test-credentials)
 - [Troubleshooting](#troubleshooting)
+- [Operator documentation](#operator-documentation)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -300,6 +301,16 @@ docker ps
 - **`generate-cert.sh` fails with "Let's Encrypt certs not found"**: Run certbot first to issue the wildcard certificate before starting the stack. Check that `/etc/letsencrypt/live/<BASE_DOMAIN>/` exists and is readable.
 - **Services failing to start**: Check that the `twake-network` Docker network exists (`docker network ls`) and that no other service is using ports 80/443.
 - **Health check failures**: Some services (chat, tmail) depend on LemonLDAP::NG being healthy. Wait for it to be ready before starting dependent services, or use `./wrapper.sh` which handles ordering automatically.
+
+## Operator documentation
+
+Deeper operational notes live in [`docs/`](docs/README.md):
+
+- [`operations.md`](docs/operations.md): host prerequisites, boot ordering, version floors
+- [`scim-import.md`](docs/scim-import.md): bulk-importing users via SCIM, end-to-end verification
+- [`external-oidc.md`](docs/external-oidc.md): plugging in an external OpenID Connect provider
+
+Bulk user provisioning script: [`scripts/scim-import-users.sh`](scripts/scim-import-users.sh) (see [`scripts/README.md`](scripts/README.md)).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Operator docs
+
+| Topic | Read |
+| --- | --- |
+| Host prereqs, boot order, version floors | [operations.md](operations.md) |
+| Importing users via SCIM, end-to-end check | [scim-import.md](scim-import.md) |
+| Plugging in an external OIDC provider | [external-oidc.md](external-oidc.md) |

--- a/docs/external-oidc.md
+++ b/docs/external-oidc.md
@@ -1,0 +1,83 @@
+# External OIDC integration
+
+LemonLDAP-NG can delegate authentication to an external OpenID Connect provider while keeping the local LDAP as the user attribute store. This page covers how to plug in a provider and what they have to support.
+
+## What the provider has to support
+
+The integration relies on the standard OIDC bits, nothing exotic:
+
+- A reachable `.well-known/openid-configuration` discovery document.
+- `authorization_code` grant.
+- ID tokens signed with `RS256` (read from the `jwks_uri` in the discovery doc).
+- `client_secret_post` for token endpoint authentication.
+- Scopes `openid`, `profile`, `email`.
+- A `sub` claim that you can use as the username, either directly (when the OP's `sub` is a stable handle like `alice`) or by remapping the LemonLDAP `uid` field to a different claim (`preferred_username`, `email`, …) when `sub` is opaque.
+
+Any provider that ticks those boxes works: tested with the in-house LemonLDAP-NG OP (the `sign-up` portal at Linagora) and with Keycloak. Other compliant providers (Authentik, Dex, …) should work; you may need to adjust the claim mapping if their `sub` shape differs.
+
+## Register the client at the OP
+
+Before configuring the stack, register an OIDC client at the provider with:
+
+| Setting | Value |
+| --- | --- |
+| Redirect URI | `https://auth.<BASE_DOMAIN>/?openidconnectcallback=1` |
+| Grant types | `authorization_code` |
+| Token endpoint auth method | `client_secret_post` |
+| Scopes | `openid profile email` |
+
+Note the resulting **client ID**, **client secret**, and the **discovery URL**.
+
+## Configure the stack
+
+In `.env`:
+
+```ini
+AUTH_MODE=OpenIDConnect
+OIDC_OP_NAME=<short label, e.g. "company">
+OIDC_OP_DISCOVERY_URL=<https://your-op/.well-known/openid-configuration>
+OIDC_CLIENT_ID=<from the OP>
+OIDC_CLIENT_SECRET=<from the OP>
+```
+
+`OIDC_OP_NAME` is a stable label that becomes a JSON key in the rendered config and shows up in logs. Pick something short.
+
+Bring the auth stack up:
+
+```bash
+cd twake_auth
+./compose-wrapper.sh up -d
+```
+
+The wrapper picks the OIDC template, fetches the discovery doc, and splices it into `lmConf-1.json` along with the client credentials. If switching from `LDAP` to `OpenIDConnect` mode on a running stack, see [`twake_auth/README.md`](../twake_auth/README.md) for the cached-config wipe step.
+
+## Provision users
+
+Each user that should be able to log in has to exist in the local LDAP with `uid` equal to the OP's `sub` for that user. Use the SCIM import (see [scim-import.md](scim-import.md)). If the OP's `sub` is opaque, either provision with that opaque value as `userName` or change the OIDC `uid` mapping in `twake_auth/config/lmConf-1.json.oidc.template` to a more friendly claim.
+
+## Common failures
+
+**"Error during authentication with OpenID Provider".** Generic error page. The real cause is in `docker logs lemonldap-ng`. Two patterns to recognise:
+
+- A successful `User <name> connected from OpenIDConnect` followed by a failed `Bad (or expired) token` for the same state means the OIDC dance worked but the callback URL was replayed (browser back button, a downstream redirect loop, or a frontend that triggers the flow twice). State tokens are single-use; the first completion wins. If a redirect loop is involved, cozy is rejecting the LemonLDAP-issued ID token (see below).
+- `Wrong credentials` after a successful OP authentication means the OP's `sub` doesn't match any LDAP entry. Either the user wasn't imported, or you're matching the wrong claim.
+
+**Redirect loop between LemonLDAP and cozy.** Almost always `oidc_id` mismatch on the cozy instance. Verify:
+
+```bash
+docker exec cozyt cozy-stack instances ls --json | jq 'select(.domain == "<user>.<BASE_DOMAIN>")'
+```
+
+Either `oidc_id` doesn't match the OP's `sub` for that user, or the cozy context for the instance doesn't have `disable_password_authentication: true` in `cozy.yaml`. Easiest fix is to destroy the instance and re-import; legacy instances created before the OIDC fields existed need a one-shot `cozy-stack instances modify <domain> --oidc-id <sub>`.
+
+**Container can't reach the OP** but the host can. Two different netns. See the UFW notes in [operations.md](operations.md).
+
+## OP discovery is fetched once
+
+The wrapper grabs the OP's discovery document at `up` time and inlines it. If the OP rotates endpoints or signing keys advertised through discovery, re-render and recreate LemonLDAP:
+
+```bash
+./compose-wrapper.sh render
+docker compose --env-file ../.env rm -fv lemonldap
+./compose-wrapper.sh up -d
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,25 @@
+# Operations
+
+## Host prerequisites
+
+- **`jq`** and **`envsubst`** on the host (the auth wrapper uses both, the SCIM import script uses `jq`). The wrappers fail fast with a clear install hint if either is missing. On Debian/Ubuntu: `sudo apt-get install -y jq gettext-base`.
+- **UFW** (if enabled) must allow container egress. Containers route through the FORWARD chain and the kernel's `ip_forward`, both of which Ubuntu's hardened defaults disable. Set `DEFAULT_FORWARD_POLICY=ACCEPT` in `/etc/default/ufw`, uncomment `net/ipv4/ip_forward=1` in `/etc/ufw/sysctl.conf`, then `ufw reload`. The host being able to reach a URL doesn't tell you containers can, since they use a different netns.
+- **Cozy-stack `1.6.50-rc1` or newer.** Older builds reject `user.created` RabbitMQ messages without a passphrase hash, even on contexts marked `disable_password_authentication: true`. Symptom in `cozyt` logs: `user.created: missing passphrase hash, nacking message`.
+
+## Synapse data ownership
+
+The `matrixdotorg/synapse` image drops to uid 991 at startup regardless of the compose `user:` directive. Files in the bind-mounted `/data` must be readable by that uid or synapse crashes with `PermissionError: '/data/homeserver.yaml'`. The init container chowns `/data`. On a fresh checkout that predates that fix:
+
+```bash
+sudo chown -R 991:991 chat_app/synapse
+```
+
+## Container egress at runtime
+
+These containers reach external hosts at runtime, not just at build:
+
+- LemonLDAP fetches the OIDC discovery doc on render, JWKS at every token verification.
+- The visio-backend's entrypoint runs `apk add curl` on each boot for its healthcheck. Block alpine mirrors and the container is permanently unhealthy.
+- Cozy-stack reaches the configured OP for the OIDC dance.
+
+If egress is locked down, either bake the tools into the images or replace network-dependent healthchecks with stdlib alternatives.

--- a/docs/scim-import.md
+++ b/docs/scim-import.md
@@ -1,0 +1,113 @@
+# SCIM import: worked example
+
+End-to-end run of the bulk user import against a deployed stack. Assumes the stack is up, `.env` populated, and the cozy-stack version is at least `1.6.50-rc1` (see [operations.md](operations.md)).
+
+## 1. Prepare `users.json`
+
+Each entry needs a valid `userName`, given/family name, and email. The `userName` becomes the cozy instance subdomain and (in OIDC mode) must match the OP's `sub` claim for that user.
+
+```json
+[
+  {
+    "userName": "alice",
+    "givenName": "Alice",
+    "familyName": "DURAND",
+    "email": "alice@example.org"
+  },
+  {
+    "userName": "bob",
+    "givenName": "Bob",
+    "familyName": "MARTIN",
+    "email": "bob@example.org"
+  }
+]
+```
+
+`userName` must be a valid DNS label: lowercase letters, digits, hyphens, no leading or trailing hyphen, ≤63 chars. The script rejects the whole batch if any entry fails this check.
+
+## 2. Run the import
+
+```bash
+./scripts/scim-import-users.sh scripts/users.json
+```
+
+To target a remote deployment without changing `.env`:
+
+```bash
+LDAP_REST_HOST=https://ldap-rest.example.org ./scripts/scim-import-users.sh scripts/users.json
+```
+
+Use `--dry-run` to print the SCIM bodies without sending anything.
+
+A clean run looks like:
+
+```
+→ Importing 2 user(s) from scripts/users.json
+  target: https://ldap-rest.example.org/scim/v2/Users
+
+  alice                    ... OK (201)
+  bob                      ... OK (201)
+
+Done: 2 created, 0 failed
+```
+
+`409 uniqueness` means the user already exists in LDAP; `4xx` other than 409 is a real failure, with the response body printed inline.
+
+## 3. Verify each layer
+
+The import touches LDAP, cozy-stack, and RabbitMQ. Check all three.
+
+**LDAP.** The SCIM list shows the new entries:
+
+```bash
+curl -k -sS -H "Authorization: Bearer $LDAP_REST_ADMIN_TOKEN" \
+  https://ldap-rest.example.org/scim/v2/Users | jq -r '.Resources[] | "\(.id)\t\(.userName)"'
+```
+
+**Cozy instances.** One per imported user, status `onboarded`:
+
+```bash
+docker exec cozyt cozy-stack instances ls
+```
+
+For each instance, `oidc_id` should equal the `userName`:
+
+```bash
+docker exec cozyt cozy-stack instances ls --json | jq 'select(.oidc_id != null) | {domain, oidc_id}'
+```
+
+**Cozy-stack consumed the events.** Tail the cozyt log around the import. You want a `skipping passphrase update` line per user (the OIDC bypass) and a `created organization contact` line for each cross-instance pairing:
+
+```bash
+docker logs --since 5m cozyt 2>&1 | grep -E "user\.created|skipping passphrase|organization contact|nacking"
+```
+
+A failed message ends with `nacking message`; on `1.6.50-rc1+` the only common nack is `organization has no instances`, which only fires if the instance lookup races the consumer (rare and self-healing on the next message).
+
+**RabbitMQ queues drained:**
+
+```bash
+docker exec rabbitmq rabbitmqctl list_queues name messages consumers \
+  | grep -E 'stack\.user\.created|auth\.dlq'
+```
+
+`messages` should be 0 and `consumers` ≥ 1. Anything in `auth.dlq` is a hard failure: the message landed in the dead-letter queue after exhausting retries.
+
+## 4. Login flow (when AUTH_MODE=OpenIDConnect)
+
+Open `https://<userName>.<BASE_DOMAIN>` in an incognito window. The flow is OP login → LemonLDAP callback → cozy redirect → instance home. If you see "Error during authentication with OpenID Provider", read [external-oidc.md](external-oidc.md).
+
+## Cleanup
+
+`SCIM DELETE` removes the LDAP entry but does not destroy the cozy instance. A subsequent `POST` for the same `userName` re-attaches to the existing instance, which can leave `oidc_id` set to a stale value. For a real reset:
+
+```bash
+# delete via SCIM (clears LDAP)
+curl -k -sS -X DELETE -H "Authorization: Bearer $LDAP_REST_ADMIN_TOKEN" \
+  https://ldap-rest.example.org/scim/v2/Users/alice
+
+# destroy the cozy instance
+docker exec cozyt cozy-stack instances destroy alice.example.org --force
+```
+
+Then re-import.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,7 +32,9 @@ Each entry in the JSON array can be either:
 - a **shorthand** with the common keys (`userName`, `givenName`, `familyName`, `email`, `active`), plus any extra top-level SCIM attributes (`displayName`, `phoneNumbers`, `title`, custom extension URNs, …) which get merged onto the synthesized body, or
 - a **full SCIM User** (anything with a `schemas` field), passed through verbatim.
 
-See `scripts/users.example.json` for a worked example covering both modes. `userName` is the only field that is always required — it becomes the cozy instance subdomain (`<userName>.${BASE_DOMAIN}`).
+See `scripts/users.example.json` for a worked example covering both modes. `userName` is required and must be a valid DNS label (lowercase letters, digits, hyphens, ≤63 chars, no leading or trailing hyphen) since it becomes the cozy instance subdomain `<userName>.${BASE_DOMAIN}`. The script validates every entry before sending and aborts the batch if any are invalid.
+
+For an end-to-end walkthrough including how to verify the import landed in LDAP, cozy, and RabbitMQ, see [`docs/scim-import.md`](../docs/scim-import.md).
 
 ### Verifying a run
 

--- a/scripts/scim-import-users.sh
+++ b/scripts/scim-import-users.sh
@@ -52,7 +52,7 @@ fi
 
 [[ -f "$ENV_FILE" ]] || { echo "ERR: .env not found at $ENV_FILE" >&2; exit 1; }
 [[ -f "$INPUT" ]]    || { echo "ERR: input file not found: $INPUT" >&2; exit 1; }
-command -v jq >/dev/null || { echo "ERR: jq is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERR: jq is required. Install: sudo apt-get install -y jq (Debian/Ubuntu) or equivalent." >&2; exit 1; }
 
 # shellcheck disable=SC1090
 set -a; source "$ENV_FILE"; set +a
@@ -62,6 +62,29 @@ set -a; source "$ENV_FILE"; set +a
 HOST="${LDAP_REST_HOST:-https://ldap-rest.${BASE_DOMAIN}}"
 
 count=$(jq 'length' "$INPUT")
+
+# userName becomes the cozy instance subdomain. Stricter than cozy-stack's own
+# check because underscores, dots, and uppercase break traefik / lemonldap
+# elsewhere in the stack.
+slug_re='^[a-z0-9](([a-z0-9-]*[a-z0-9])?)$'
+invalid=()
+i=0
+while IFS= read -r uname; do
+  if [[ -z "$uname" ]]; then
+    invalid+=("entry #$i: missing userName")
+  elif (( ${#uname} > 63 )); then
+    invalid+=("$uname: longer than 63 chars")
+  elif ! [[ "$uname" =~ $slug_re ]]; then
+    invalid+=("$uname: not a valid DNS label (lowercase letters, digits, hyphens; no leading/trailing hyphen)")
+  fi
+  i=$((i + 1))
+done < <(jq -r '.[].userName // ""' "$INPUT")
+if (( ${#invalid[@]} > 0 )); then
+  echo "ERR: invalid userName(s), nothing imported:" >&2
+  printf '  - %s\n' "${invalid[@]}" >&2
+  exit 1
+fi
+
 echo "→ Importing $count user(s) from $INPUT"
 echo "  target: $HOST/scim/v2/Users"
 [[ $DRY_RUN -eq 1 ]] && echo "  (dry-run: no requests will be sent)"

--- a/twake_auth/compose-wrapper.sh
+++ b/twake_auth/compose-wrapper.sh
@@ -2,6 +2,15 @@
 # compose-wrapper.sh
 set -e
 
+command -v jq >/dev/null || {
+  echo "ERR: jq is required by this wrapper. Install: sudo apt-get install -y jq (Debian/Ubuntu) or equivalent." >&2
+  exit 1
+}
+command -v envsubst >/dev/null || {
+  echo "ERR: envsubst is required by this wrapper. Install: sudo apt-get install -y gettext-base (Debian/Ubuntu) or equivalent." >&2
+  exit 1
+}
+
 ACTION="$1"
 
 # Load environment variables


### PR DESCRIPTION
## Summary

- Add operator-facing docs covering host prerequisites and version floors, an end-to-end SCIM import walkthrough with verification steps for each layer (LDAP, cozy, RabbitMQ), and what an external OIDC provider has to support to integrate.
- Validate `userName` as a DNS label in the SCIM import script before any API call, so an invalid entry can't poison part of the batch.
- Fail fast in the auth wrapper when `jq` or `envsubst` is missing, with a concrete install hint, instead of producing a misleading downstream error.
- Link the new docs from the root README and `scripts/README.md`.