### PR TITLE
feat: cozy default feature flags and sharing trust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ tmail_app/tmail-web-conf/.env
 meet_app/config/nginx.conf
 linshare_app/config/backend/linshare.extra.properties
 linshare_app/config/user-ui/config.js
-cozy-stack/config/cozy.yaml
+cozy_stack/config/cozy.yaml
+cozy_stack/config/*.local.yaml
 chat_app/synapse/homeserver-postgres.yaml
 chat_app/synapse/wellknownclient.conf
 chat_app/synapse/wellknownserver.conf

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Deeper operational notes live in [`docs/`](docs/README.md):
 - [`operations.md`](docs/operations.md): host prerequisites, boot ordering, version floors
 - [`scim-import.md`](docs/scim-import.md): bulk-importing users via SCIM, end-to-end verification
 - [`external-oidc.md`](docs/external-oidc.md): plugging in an external OpenID Connect provider
+- [`cozy-defaults.md`](docs/cozy-defaults.md): cozy default context settings (passphrase bypass, feature flags, sharing trust)
 
 Bulk user provisioning script: [`scripts/scim-import-users.sh`](scripts/scim-import-users.sh) (see [`scripts/README.md`](scripts/README.md)).
 

--- a/cozy_stack/compose-wrapper.sh
+++ b/cozy_stack/compose-wrapper.sh
@@ -7,16 +7,49 @@ ACTION="$1"
 set -a
 source ../.env
 set +a
-if [ "$ACTION" = "up" ]; then
- # Process configuration
- echo "Processing configuration..."
- envsubst '$BASE_DOMAIN' < ./config/cozy.yaml.template > config/cozy.yaml
 
- # Check if file was created
- if [ ! -f "config/cozy.yaml" ]; then
-    echo "Failed to create configuration file"
-    exit 1
- fi
+# pick_default returns the path of the *.local.yaml override if it exists,
+# else the committed default file. Lets operators override the cozy default
+# context (feature flags, sharing trust) per deployment without modifying
+# tracked files.
+pick_default() {
+  local name="$1"
+  if [ -f "config/${name}.local.yaml" ]; then
+    echo "config/${name}.local.yaml"
+  else
+    echo "config/${name}.yaml"
+  fi
+}
+
+# splice replaces a marker line in the rendered cozy.yaml with the contents
+# of $2, indented by $3 spaces. Both the template and the spliced files go
+# through envsubst for $BASE_DOMAIN expansion. The body is passed through
+# ENVIRON rather than awk's -v so backslashes in operator overrides are not
+# interpreted as escape sequences during assignment.
+splice() {
+  local marker="$1" file="$2" indent="$3"
+  local pad
+  pad=$(printf '%*s' "$indent" '')
+  SPLICE_BODY=$(envsubst '$BASE_DOMAIN' < "$file" | sed "s/^/${pad}/")
+  export SPLICE_BODY
+  awk -v m="$marker" 'BEGIN{r=ENVIRON["SPLICE_BODY"]} $0 == m {print r; next} {print}' \
+    config/cozy.yaml > config/cozy.yaml.tmp
+  unset SPLICE_BODY
+  mv config/cozy.yaml.tmp config/cozy.yaml
+}
+
+if [ "$ACTION" = "up" ] || [ "$ACTION" = "render" ]; then
+  echo "Processing configuration..."
+  envsubst '$BASE_DOMAIN' < ./config/cozy.yaml.template > config/cozy.yaml
+
+  flags_file=$(pick_default default-flags)
+  sharing_file=$(pick_default default-sharing)
+  echo "  flags:   $flags_file"
+  echo "  sharing: $sharing_file"
+  splice '__DEFAULT_FLAGS__'   "$flags_file"   6
+  splice '__DEFAULT_SHARING__' "$sharing_file" 6
+
+  if [ "$ACTION" = "render" ]; then exit 0; fi
 fi
 
 

--- a/cozy_stack/config/cozy.yaml.template
+++ b/cozy_stack/config/cozy.yaml.template
@@ -565,14 +565,15 @@ contexts:
         - example.com
         - mycompany.twake.app
 
-  # Default context - used as fallback when instance context is not specified
-  # or when a context doesn't have sharing configuration
+  # Default context. Sharing trust and feature flags are spliced in at
+  # render time from cozy_stack/config/default-sharing.yaml and
+  # cozy_stack/config/default-flags.yaml (or the matching *.local.yaml
+  # override). See docs/cozy-defaults.md.
   default:
     sharing:
-      # Conservative defaults for production
-      auto_accept_trusted: false
-      auto_accept_trusted_contacts: false
-      trusted_domains: []
+__DEFAULT_SHARING__
+    features:
+__DEFAULT_FLAGS__
 
 rabbitmq:
   enabled: true

--- a/cozy_stack/config/default-flags.yaml
+++ b/cozy_stack/config/default-flags.yaml
@@ -1,0 +1,63 @@
+# Default feature flags for the cozy `default` context. Spliced into
+# cozy.yaml at render time. To override for a specific deployment, copy
+# this file to `default-flags.local.yaml` (gitignored) and edit. The
+# wrapper uses the `.local.yaml` if it exists, otherwise this file.
+#
+# Each entry is a list of `{ratio, value}` pairs (the weighted-flag shape
+# cozy-stack expects).
+apps.hidden:
+  - ratio: 1
+    value:
+      - dataproxy
+      - mespapiers
+cozy.hide-sharing-cozy-to-cozy:
+  - ratio: 1
+    value: true
+cozy.search.enabled:
+  - ratio: 1
+    value: true
+drive.default-updated-at-sort.enabled:
+  - ratio: 1
+    value: false
+drive.doubleclick.enabled:
+  - ratio: 1
+    value: true
+drive.folder-personalization.enabled:
+  - ratio: 1
+    value: true
+drive.highlight-new-items.enabled:
+  - ratio: 1
+    value: true
+drive.keyboard-shortcuts.enabled:
+  - ratio: 1
+    value: true
+drive.shared-drive.enabled:
+  - ratio: 1
+    value: false
+drive.twake-creation-from-public-sharing.disabled:
+  - ratio: 1
+    value: true
+drive.update-favicon.enabled:
+  - ratio: 1
+    value: true
+drive.virtualization.enabled:
+  - ratio: 1
+    value: true
+home.wallpaper-personalization.enabled:
+  - ratio: 1
+    value: true
+settings.partial-desktop-sync.show-synced-folders-selection:
+  - ratio: 1
+    value: false
+sharing.auto-open-settings.enabled:
+  - ratio: 1
+    value: true
+sharing.data-toggle.enabled:
+  - ratio: 1
+    value: true
+sharing.generate-link-button.enabled:
+  - ratio: 1
+    value: true
+ui.theme-twake.enabled:
+  - ratio: 1
+    value: true

--- a/cozy_stack/config/default-sharing.yaml
+++ b/cozy_stack/config/default-sharing.yaml
@@ -1,0 +1,11 @@
+# Default cozy-to-cozy sharing trust policy for the `default` context.
+# Spliced into cozy.yaml at render time. To override for a specific
+# deployment, copy this file to `default-sharing.local.yaml` (gitignored)
+# and edit. The wrapper uses the `.local.yaml` if it exists, otherwise
+# this file.
+#
+# `${BASE_DOMAIN}` is substituted by the wrapper at render time.
+auto_accept_trusted: true
+auto_accept_trusted_contacts: true
+trusted_domains:
+  - ${BASE_DOMAIN}

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@
 | Host prereqs, boot order, version floors | [operations.md](operations.md) |
 | Importing users via SCIM, end-to-end check | [scim-import.md](scim-import.md) |
 | Plugging in an external OIDC provider | [external-oidc.md](external-oidc.md) |
+| Cozy default context settings         | [cozy-defaults.md](cozy-defaults.md)  |

--- a/docs/cozy-defaults.md
+++ b/docs/cozy-defaults.md
@@ -1,0 +1,65 @@
+# Cozy default context settings
+
+In this stack, every instance provisioned through cozyProvision is created in the `default` context (see `COZY_CONTEXT_NAME` in `.env`). Cozy-stack reads context-keyed config from two top-level blocks in the rendered `cozy.yaml`: `authentication.default` and `contexts.default`. The first lives inline in `cozy_stack/config/cozy.yaml.template`. The second is composed at render time from `default-sharing.yaml` and `default-flags.yaml` (each overridable via a `*.local.yaml` sibling).
+
+## Authentication: forced OIDC
+
+```yaml
+authentication:
+  default:
+    disable_password_authentication: true
+    oidc:
+      client_id: IDCOZY
+      client_secret: secretcozy
+      authorize_url: https://auth.${BASE_DOMAIN}/oauth2/authorize
+      token_url:     https://auth.${BASE_DOMAIN}/oauth2/token
+      userinfo_url:  https://auth.${BASE_DOMAIN}/oauth2/userinfo
+      id_token_jwk_url: https://auth.${BASE_DOMAIN}/oauth2/jwks
+      logout_url:    https://auth.${BASE_DOMAIN}/oauth2/logout
+      ...
+```
+
+`disable_password_authentication: true` is what cozy-stack's `Instance.HasForcedOIDC()` returns. One observable consequence: the `user.created` RabbitMQ consumer accepts messages without a passphrase hash for instances in this context (it logs `skipping passphrase update for instance ... (forced OIDC context: default)`). Without the flag, cozy-stack nacks those messages with `missing passphrase hash`.
+
+The `oidc:` block configures cozy-stack as an OIDC RP against LemonLDAP-NG (the URLs all point at `auth.${BASE_DOMAIN}`). For details on the LemonLDAP side and plugging in an external upstream OP, see [external-oidc.md](external-oidc.md).
+
+## Feature flags
+
+Defined in `cozy_stack/config/default-flags.yaml` (a YAML map of flag name to a list of `{ratio, value}` pairs). The wrapper splices that file into `contexts.default.features` of the rendered `cozy.yaml` at startup.
+
+To override per deployment, copy the file alongside it as `default-flags.local.yaml` and edit. The wrapper picks the `.local.yaml` if it exists, otherwise the committed default. The local file is gitignored.
+
+Inspect the flags cozy-stack actually loaded for the default context:
+
+```bash
+docker exec cozyt cozy-stack feature config --context default
+```
+
+Inspect the effective flags on a specific instance, with their source:
+
+```bash
+docker exec cozyt cozy-stack feature show --domain <user>.<BASE_DOMAIN> --source
+```
+
+In the `--source` output, instance-level flags (`io.cozy.settings.flags.instance`) are listed before config-level flags (`io.cozy.settings.flags.config`); when both define the same key the instance value wins.
+
+To apply a change, re-render and reload:
+
+```bash
+cd cozy_stack
+./compose-wrapper.sh render   # rewrite cozy.yaml from template + defaults
+docker restart cozyt
+```
+
+## Sharing trust
+
+Defined in `cozy_stack/config/default-sharing.yaml`:
+
+```yaml
+auto_accept_trusted: true
+auto_accept_trusted_contacts: true
+trusted_domains:
+  - ${BASE_DOMAIN}
+```
+
+Same override pattern as the flags file: copy to `default-sharing.local.yaml` to override per deployment. `${BASE_DOMAIN}` is substituted by the wrapper at render time, so all instances inside the same deployment list each other's parent domain as trusted. With `auto_accept_trusted: true` and `auto_accept_trusted_contacts: true`, sharing invitations between users in the same workplace go through without each side manually confirming. Add more entries to `trusted_domains` to extend trust to other deployments.


### PR DESCRIPTION
## Summary

- Set the Twake Workplace UI feature flags under `contexts.default` in cozy.yaml so every provisioned instance gets a consistent app, drive, and sharing experience without per-instance configuration.
- Trust the deployment's `BASE_DOMAIN` for cozy-to-cozy sharing and turn on `auto_accept_trusted` plus `auto_accept_trusted_contacts`, so users inside the same workplace can share with each other without manually confirming each invitation.
- Add a short docs page describing the default context, how to inspect the loaded flags, and the precedence between instance-level and context-level flags.