### PR TITLE
fix: ensure rendered cozy.yaml is readable by the container uid

### DIFF
--- a/cozy_stack/compose-wrapper.sh
+++ b/cozy_stack/compose-wrapper.sh
@@ -49,6 +49,11 @@ if [ "$ACTION" = "up" ] || [ "$ACTION" = "render" ]; then
   splice '__DEFAULT_FLAGS__'   "$flags_file"   6
   splice '__DEFAULT_SHARING__' "$sharing_file" 6
 
+  # cozy-stack runs inside the container as a non-root uid (3552). The bind-
+  # mounted config has to be readable by it regardless of the host operator's
+  # umask, so force a sane mode after the splice.
+  chmod 644 config/cozy.yaml
+
   if [ "$ACTION" = "render" ]; then exit 0; fi
 fi
 


### PR DESCRIPTION
## Summary

- Force `644` on the rendered `cozy.yaml` after the splice step. Cozy-stack inside the container runs as a non-root uid and the post-splice tmp-and-mv flow inherits the operator's umask, which on a hardened host can leave the file mode at `600` and the container hitting `permission denied` on `/etc/cozy/cozy.yaml` at startup.