### PR TITLE
feat: enable drive.federated-shared-folder by default

### DIFF
--- a/cozy_stack/config/default-flags.yaml
+++ b/cozy_stack/config/default-flags.yaml
@@ -22,6 +22,9 @@ drive.default-updated-at-sort.enabled:
 drive.doubleclick.enabled:
   - ratio: 1
     value: true
+drive.federated-shared-folder.enabled:
+  - ratio: 1
+    value: true
 drive.folder-personalization.enabled:
   - ratio: 1
     value: true


### PR DESCRIPTION
## Summary

- Add `drive.federated-shared-folder.enabled` to the default-flags list.