### PR TITLE
fix: cozy default flags ignored by frontend due to wrong yaml shape

### DIFF
--- a/cozy_stack/config/default-flags.yaml
+++ b/cozy_stack/config/default-flags.yaml
@@ -3,64 +3,26 @@
 # this file to `default-flags.local.yaml` (gitignored) and edit. The
 # wrapper uses the `.local.yaml` if it exists, otherwise this file.
 #
-# Each entry is a list of `{ratio, value}` pairs (the weighted-flag shape
-# cozy-stack expects).
-apps.hidden:
-  - ratio: 1
-    value:
-      - dataproxy
-      - mespapiers
-cozy.hide-sharing-cozy-to-cozy:
-  - ratio: 1
-    value: true
-cozy.search.enabled:
-  - ratio: 1
-    value: true
-drive.default-updated-at-sort.enabled:
-  - ratio: 1
-    value: false
-drive.doubleclick.enabled:
-  - ratio: 1
-    value: true
-drive.federated-shared-folder.enabled:
-  - ratio: 1
-    value: true
-drive.folder-personalization.enabled:
-  - ratio: 1
-    value: true
-drive.highlight-new-items.enabled:
-  - ratio: 1
-    value: true
-drive.keyboard-shortcuts.enabled:
-  - ratio: 1
-    value: true
-drive.shared-drive.enabled:
-  - ratio: 1
-    value: false
-drive.twake-creation-from-public-sharing.disabled:
-  - ratio: 1
-    value: true
-drive.update-favicon.enabled:
-  - ratio: 1
-    value: true
-drive.virtualization.enabled:
-  - ratio: 1
-    value: true
-home.wallpaper-personalization.enabled:
-  - ratio: 1
-    value: true
-settings.partial-desktop-sync.show-synced-folders-selection:
-  - ratio: 1
-    value: false
-sharing.auto-open-settings.enabled:
-  - ratio: 1
-    value: true
-sharing.data-toggle.enabled:
-  - ratio: 1
-    value: true
-sharing.generate-link-button.enabled:
-  - ratio: 1
-    value: true
-ui.theme-twake.enabled:
-  - ratio: 1
-    value: true
+# Format: a YAML list of single-key maps with resolved values (matches
+# cozy-stack's reference config in pkg/config/config/testdata/full_config.yaml).
+- apps.hidden:
+    - dataproxy
+    - mespapiers
+- cozy.hide-sharing-cozy-to-cozy: true
+- cozy.search.enabled: true
+- drive.default-updated-at-sort.enabled: false
+- drive.doubleclick.enabled: true
+- drive.federated-shared-folder.enabled: true
+- drive.folder-personalization.enabled: true
+- drive.highlight-new-items.enabled: true
+- drive.keyboard-shortcuts.enabled: true
+- drive.shared-drive.enabled: false
+- drive.twake-creation-from-public-sharing.disabled: true
+- drive.update-favicon.enabled: true
+- drive.virtualization.enabled: true
+- home.wallpaper-personalization.enabled: true
+- settings.partial-desktop-sync.show-synced-folders-selection: false
+- sharing.auto-open-settings.enabled: true
+- sharing.data-toggle.enabled: true
+- sharing.generate-link-button.enabled: true
+- ui.theme-twake.enabled: true


### PR DESCRIPTION
## Summary

- The `[{ratio: 1, value: ...}]` shape we shipped for `default-flags.yaml` is the shape used by `cozy-stack feature ratio --context X` (which writes to CouchDB and gets resolved on read), not the shape cozy.yaml expects. The cozy.yaml loader stores values as-is, so every flag was reaching the frontend wrapped: `apps.hidden` was a list of ratio objects instead of a list of app slugs, and booleans were truthy arrays instead of bare booleans. None of the defaults actually took effect.
- Rewrite `default-flags.yaml` in the resolved-value shape documented in cozy-stack's reference config (`pkg/config/config/testdata/full_config.yaml`): a list of single-key maps with the final value inline, no ratio scaffolding.
- Verified against a freshly created instance via `/settings/flags`: `apps.hidden` is now `["dataproxy", "mespapiers"]` and booleans are bare booleans, matching what the cozy frontend reads.