### PR TITLE
fix: in-network dns so cozy-to-cozy sharing reaches traefik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore database data
 twake_db/ldap/bootstrap/users.ldif
 twake_auth/config/lmConf-1.json
+twake_auth/config/dnsmasq.conf
 tmail_app/config/domainlist.xml
 tmail_app/config/jmap.properties
 tmail_app/config/mailetcontainer.xml

--- a/cozy_stack/docker-compose.yml
+++ b/cozy_stack/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       COZY_ADMIN_PASSPHRASE: ${COZY_ADMIN_PASSPHRASE:-admin}
       INBOX_SECRET: secret
       OUTBOX_SECRET: secret
+    # Use the in-network dnsmasq (twake_auth/dns) to resolve any subdomain of
+    # BASE_DOMAIN to traefik so cozy-to-cozy sharing requests stay inside the
+    # docker bridge instead of looping through the host's public IP.
+    dns:
+      - 172.27.0.53
     extra_hosts:
       - "auth.${BASE_DOMAIN}:172.27.0.100"
     volumes:

--- a/twake_auth/Dockerfile.dnsmasq
+++ b/twake_auth/Dockerfile.dnsmasq
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+RUN apk add --no-cache dnsmasq
+ENTRYPOINT ["dnsmasq", "--no-daemon", "--conf-file=/etc/dnsmasq.conf", "--log-facility=-"]

--- a/twake_auth/compose-wrapper.sh
+++ b/twake_auth/compose-wrapper.sh
@@ -85,13 +85,21 @@ render_lmconf() {
   echo "✔ config/lmConf-1.json generated (AUTH_MODE=$AUTH_MODE)"
 }
 
+render_dnsmasq() {
+  echo "Processing dnsmasq configuration..."
+  envsubst '$BASE_DOMAIN' < ./config/dnsmasq.conf.template > config/dnsmasq.conf
+  echo "✔ config/dnsmasq.conf generated"
+}
+
 if [ "$ACTION" = "render" ]; then
   render_lmconf
+  render_dnsmasq
   exit 0
 fi
 
 if [ "$ACTION" = "up" ]; then
   render_lmconf
+  render_dnsmasq
 
   if [ "${CERT_MODE:-self-signed}" = "letsencrypt" ] || \
      [ ! -f "traefik/ssl/twake-server.pem" ] || [ ! -f "traefik/ssl/root-ca.crt" ]; then

--- a/twake_auth/config/dnsmasq.conf.template
+++ b/twake_auth/config/dnsmasq.conf.template
@@ -1,0 +1,29 @@
+# Internal DNS for the twake-network. Resolves any subdomain of
+# ${BASE_DOMAIN} to traefik (172.27.0.100) so containers calling each
+# other through public hostnames stay inside the docker bridge instead
+# of routing through the host's public IP and the NAT hairpin.
+#
+# Anything not matching the wildcard is forwarded to Docker's embedded
+# DNS at 127.0.0.11, which itself handles container service-name
+# resolution and forwards external queries upstream.
+
+# Don't read /etc/resolv.conf or /etc/hosts inside the container; we
+# define everything explicitly here so the behaviour is deterministic.
+no-resolv
+no-hosts
+
+# Wildcard: *.${BASE_DOMAIN} (and the bare ${BASE_DOMAIN}) -> traefik.
+address=/${BASE_DOMAIN}/172.27.0.100
+
+# Fallback: forward everything else to Docker's embedded DNS so service
+# names (rabbitmq, couchdb, ldap, ...) and external hosts still resolve.
+server=127.0.0.11
+
+# Listen on every interface (we're a container, only the docker bridge
+# can reach us).
+listen-address=0.0.0.0
+bind-interfaces
+
+# Useful while bringing this up; turn off later if log volume becomes
+# an issue.
+log-queries

--- a/twake_auth/docker-compose.yml
+++ b/twake_auth/docker-compose.yml
@@ -158,6 +158,26 @@ services:
       twake-network:
         ipv4_address: 172.27.0.100
 
+  dns:
+    container_name: stack-dns
+    build:
+      context: .
+      dockerfile: Dockerfile.dnsmasq
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - ./config/dnsmasq.conf:/etc/dnsmasq.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep dnsmasq"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      twake-network:
+        ipv4_address: 172.27.0.53
+
   twake-docker-socket:
     container_name: docker-socket
     image: tecnativa/docker-socket-proxy


### PR DESCRIPTION
## Summary

- Cozy-to-cozy sharing opens HTTPS connections to other instances by their public hostname. Inside the docker network those names resolve to the host's public IP, so the connection has to go out through NAT and come back via the host's eth0. On hosts where that hairpin path is broken (firewall, asymmetric routing, no hairpin support) the connect silently times out and the cozy-stack sharing code falls back to email, which most operators don't want and which fails on its own when SMTP is a placeholder.
- Add a small dnsmasq container on the twake-network with a wildcard for `BASE_DOMAIN` that points every subdomain at traefik. Cozyt is configured to use it as DNS, so sharing requests stay on the docker bridge, hit traefik directly, and route to the right instance container, with the existing `auto_accept_trusted` policy applying as intended.
- External lookups and docker service-name resolution keep working because dnsmasq forwards anything outside the wildcard to the embedded resolver at `127.0.0.11`.