### PR TITLE
feat: reject reserved subdomains in users add

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,7 +48,7 @@ scripts/twake users add <userName> [flags] [--dry-run]
 scripts/twake users add --file <path>   [--dry-run]
 ```
 
-`<userName>` must be a valid DNS label — lowercase letters, digits, hyphens, no leading/trailing hyphen, ≤63 chars. It becomes the cozy instance subdomain `<userName>.${BASE_DOMAIN}`.
+`<userName>` must be a valid DNS label: lowercase letters, digits, hyphens, no leading/trailing hyphen, ≤63 chars. It becomes the cozy instance subdomain `<userName>.${BASE_DOMAIN}`. Slugs that match a stack service subdomain (e.g. `chat`, `mail`, `auth`) are rejected to avoid traefik routing collisions; the list is derived at runtime from the `Host(...)` rules in every `docker-compose*.y*ml` under the repo, so it stays in sync as services are added or removed.
 
 In file mode the file is **one SCIM User object or an array**. Every SCIM attribute (extension URNs, addresses, custom claims) is forwarded to ldap-rest verbatim. Each entry is either:
 - a full SCIM User (anything with a `schemas` field), or

--- a/docs/scim-import.md
+++ b/docs/scim-import.md
@@ -23,7 +23,7 @@ Each entry needs a valid `userName`, given/family name, and email. The `userName
 ]
 ```
 
-`userName` must be a valid DNS label: lowercase letters, digits, hyphens, no leading or trailing hyphen, ≤63 chars. The script rejects the whole batch if any entry fails this check.
+`userName` must be a valid DNS label: lowercase letters, digits, hyphens, no leading or trailing hyphen, ≤63 chars. It must also not collide with a stack service subdomain (e.g. `chat`, `mail`, `auth`); the reserved set is derived at runtime from the `Host(...)` rules in the repo's compose files. The script rejects the whole batch if any entry fails either check.
 
 ## 2. Run the import
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,4 +38,4 @@ The end-to-end SCIM import walkthrough lives in [`docs/scim-import.md`](../docs/
 
 `users.example.json` is a sample input file accepted by both `users add --file` and `users destroy --file`. Each entry is either a SCIM `User` object (anything with a `schemas` field, passed through verbatim) or a shorthand combining `userName`, `givenName`, `familyName`, `email`, `active`, plus any extra top-level SCIM fields you want merged onto the synthesized body.
 
-`userName` must be a valid DNS label — lowercase letters, digits, hyphens, no leading or trailing hyphen, ≤63 chars — because it becomes the cozy instance subdomain `<userName>.${BASE_DOMAIN}`.
+`userName` must be a valid DNS label (lowercase letters, digits, hyphens, no leading or trailing hyphen, ≤63 chars) because it becomes the cozy instance subdomain `<userName>.${BASE_DOMAIN}`. Slugs that match a stack service subdomain (e.g. `chat`, `mail`, `auth`) are also rejected to avoid traefik routing collisions; the list is derived at runtime from the `Host(...)` rules in compose files, so it stays in sync as services come and go.

--- a/scripts/twake
+++ b/scripts/twake
@@ -95,6 +95,28 @@ load_env() {
 # traefik / lemonldap elsewhere in the stack.
 SLUG_RE='^[a-z0-9](([a-z0-9-]*[a-z0-9])?)$'
 
+# Subdomains already taken by stack services. Provisioning a user with one
+# of these slugs would create a DNS collision between the cozy instance
+# (https://<slug>.${BASE_DOMAIN}) and the service routed by traefik on the
+# same name. Derived at runtime from the `Host(...)` rules in every
+# docker-compose*.y*ml under the repo, so adding a service to compose
+# automatically extends the blocklist with no CLI change required.
+RESERVED_SLUGS=()
+reserved_slugs_load() {
+  (( ${#RESERVED_SLUGS[@]} > 0 )) && return 0
+  local files=()
+  shopt -s nullglob
+  files+=("$REPO_ROOT"/docker-compose*.y*ml "$REPO_ROOT"/*/docker-compose*.y*ml)
+  shopt -u nullglob
+  (( ${#files[@]} > 0 )) || die "no docker-compose*.y*ml files under $REPO_ROOT (cannot derive reserved subdomains)"
+  local raw
+  raw=$(grep -hEo 'Host\(`[a-z0-9-]+\.' "${files[@]}" 2>/dev/null \
+        | sed -E 's/^Host\(`//; s/\.$//' \
+        | sort -u) || true
+  [[ -n "$raw" ]] || die "no Host(\`<sub>.*\`) rules found in compose files (reserved-subdomain check would be empty)"
+  mapfile -t RESERVED_SLUGS <<<"$raw"
+}
+
 # Reads userNames on stdin (one per line). Prints all errors then exits 1
 # if any entry is invalid. Returns silently on success.
 validate_slugs() {
@@ -112,6 +134,29 @@ validate_slugs() {
   if (( ${#invalid[@]} > 0 )); then
     err "invalid userName(s):"
     printf '  - %s\n' "${invalid[@]}" >&2
+    exit 1
+  fi
+}
+
+# Reads userNames on stdin (one per line); errors if any matches a stack
+# service subdomain. Call only on the creation path: destroy / flags should
+# still work on legacy entries that pre-date this check.
+validate_not_reserved() {
+  reserved_slugs_load
+  # Slugs are DNS labels (no spaces or glob metachars), so the leading /
+  # trailing space sentinels make substring-containment a safe set check.
+  local haystack=" ${RESERVED_SLUGS[*]} "
+  local reserved=() u
+  while IFS= read -r u; do
+    [[ -z "$u" ]] && continue
+    [[ "$haystack" == *" $u "* ]] && reserved+=("$u")
+  done
+  if (( ${#reserved[@]} > 0 )); then
+    err "userName(s) conflict with a stack service subdomain:"
+    for u in "${reserved[@]}"; do
+      printf '  - %s (would shadow https://%s.%s)\n' \
+        "$u" "$u" "${BASE_DOMAIN:-<BASE_DOMAIN>}" >&2
+    done
     exit 1
   fi
 }
@@ -446,6 +491,7 @@ cmd_users_add() {
 
   if (( count > 0 )); then
     cut -f1 <<<"$lines" | validate_slugs
+    cut -f1 <<<"$lines" | validate_not_reserved
   fi
 
   printf '%s%s%s Provisioning %s%d user(s)%s\n' \


### PR DESCRIPTION
## Problem

The stack routes services on wildcard subdomains (`chat.<BASE>`, `mail.<BASE>`, `auth.<BASE>`, ...) and cozy instances live on that same wildcard (`<userName>.<BASE>`). Provisioning a user whose `userName` matches a service slug creates two traefik routes for the same hostname, and the user's instance ends up shadowed (or shadowing) the service.

## Solution

`scripts/twake users add` now refuses any `userName` that matches a stack service subdomain. The reserved set is built at runtime by scanning `Host(...)` rules across every `docker-compose*.y*ml` in the repo, so adding or removing a service in compose updates the block list on the next CLI run with no code change. The check is wired into the creation path only; `users destroy` and `flags ...` keep working on legacy entries that pre-date the rule.

## Example

```console
$ scripts/twake users add chat --email chat@example.org
ERROR: userName(s) conflict with a stack service subdomain:
  - chat (would shadow https://chat.example.org)
```

Same behaviour for `--file` batches: a single offender fails the whole batch before any SCIM POST.