### PR TITLE
fix: reject incomplete cozy.yaml renders before they reach the stack

### DIFF
--- a/cozy_stack/compose-wrapper.sh
+++ b/cozy_stack/compose-wrapper.sh
@@ -54,6 +54,29 @@ if [ "$ACTION" = "up" ] || [ "$ACTION" = "render" ]; then
   # umask, so force a sane mode after the splice.
   chmod 644 config/cozy.yaml
 
+  # Fail fast on an incomplete render. cozy.yaml is bind-mounted verbatim into
+  # the container, so a half-rendered file silently breaks the stack: leftover
+  # __DEFAULT_ markers make cozy-stack fail to parse the config, and an empty
+  # BASE_DOMAIN (when .env was not loaded) renders valid-but-wrong OIDC URLs
+  # like https://auth./oauth2/authorize that only surface as broken login.
+  # Catch both here, before docker ever sees the file.
+  render_errors=""
+  if grep -q '__DEFAULT_' config/cozy.yaml; then
+    render_errors="${render_errors}\n  - leftover __DEFAULT_ markers (splice did not run)"
+  fi
+  if grep -q '\${BASE_DOMAIN}' config/cozy.yaml; then
+    render_errors="${render_errors}\n  - literal \${BASE_DOMAIN} (envsubst did not run)"
+  fi
+  if grep -qE 'https://[a-z0-9-]*\./' config/cozy.yaml; then
+    render_errors="${render_errors}\n  - empty BASE_DOMAIN (rendered e.g. https://auth./); is ../.env present with BASE_DOMAIN set?"
+  fi
+  if [ -n "$render_errors" ]; then
+    echo "ERROR: config/cozy.yaml render is incomplete:" >&2
+    printf "%b\n" "$render_errors" >&2
+    rm -f config/cozy.yaml
+    exit 1
+  fi
+
   if [ "$ACTION" = "render" ]; then exit 0; fi
 fi
 

--- a/cozy_stack/config/docker-entrypoint.sh
+++ b/cozy_stack/config/docker-entrypoint.sh
@@ -57,6 +57,31 @@ if [ "${START_EMBEDDED_POSTFIX:-}" = "true" ]; then
 fi
 
 if echo "$@" | grep -q "cozy-stack "; then
+  # Refuse to start on an unrendered or half-rendered config. cozy.yaml is
+  # bind-mounted verbatim, so a file still carrying the render placeholders
+  # breaks the stack: __DEFAULT_ markers make cozy-stack fail to parse the
+  # config, and an empty BASE_DOMAIN (e.g. https://auth./) produces a stack
+  # that boots but has broken OIDC login. The host wrapper guards its own
+  # render, but a bare `docker compose up` bypasses it; this is the last line
+  # of defense. See docs/cozy-defaults.md ("Resetting a polluted stack").
+  CONFIG=/etc/cozy/cozy.yaml
+  if [ ! -f "${CONFIG}" ]; then
+    echo "FATAL: ${CONFIG} is missing. Render it with cozy_stack/compose-wrapper.sh before starting." >&2
+    exit 1
+  fi
+  if grep -q '__DEFAULT_' "${CONFIG}"; then
+    echo "FATAL: ${CONFIG} still contains __DEFAULT_ markers (config was not rendered through compose-wrapper.sh)." >&2
+    exit 1
+  fi
+  if grep -q '${BASE_DOMAIN}' "${CONFIG}"; then
+    echo "FATAL: ${CONFIG} still contains a literal \${BASE_DOMAIN} (render did not substitute the domain)." >&2
+    exit 1
+  fi
+  if grep -Eq 'https://[a-z0-9-]*\./' "${CONFIG}"; then
+    echo "FATAL: ${CONFIG} has an empty BASE_DOMAIN (e.g. https://auth./); re-render with ../.env loaded." >&2
+    exit 1
+  fi
+
   # Ensure CouchDB is ready if running an applicative subcommand
   echo "Waiting for CouchDB to be available..."
   wait-for-it.sh -h "${COUCHDB_HOST}" -p "${COUCHDB_PORT}" -t 60

--- a/docs/cozy-defaults.md
+++ b/docs/cozy-defaults.md
@@ -63,3 +63,54 @@ trusted_domains:
 ```
 
 Same override pattern as the flags file: copy to `default-sharing.local.yaml` to override per deployment. `${BASE_DOMAIN}` is substituted by the wrapper at render time, so all instances inside the same deployment list each other's parent domain as trusted. With `auto_accept_trusted: true` and `auto_accept_trusted_contacts: true`, sharing invitations between users in the same workplace go through without each side manually confirming. Add more entries to `trusted_domains` to extend trust to other deployments.
+
+## Resetting a polluted stack
+
+The rendered `cozy.yaml` is gitignored, so it survives branch switches and is never updated by `git`. If an instance was ever brought up without a correct render (for example a bare `docker compose up` at the repo root instead of `./wrapper.sh up`, or with `../.env` not loaded so `BASE_DOMAIN` was empty), the bad state can hide in three independent layers. Clean them in order and stop as soon as your case is covered.
+
+The wrapper now refuses to render a `cozy.yaml` that still contains `__DEFAULT_` markers, a literal `${BASE_DOMAIN}`, or an empty-domain URL like `https://auth./`. So re-rendering is the first thing to try: it either produces a clean file or fails loudly.
+
+### Layer 1: the rendered config file
+
+```bash
+cd cozy_stack
+rm -f config/cozy.yaml          # drop the stale or half-rendered file
+./compose-wrapper.sh render     # re-render; aborts if the result is incomplete
+```
+
+Gotcha: if Docker was ever started while `config/cozy.yaml` was absent, it auto-creates a *directory* at that path. Check with `[ -d config/cozy.yaml ] && rm -rf config/cozy.yaml`, then re-render.
+
+### Layer 2: the running container
+
+cozy-stack reads `cozy.yaml` only at startup, so a running `cozyt` keeps the old config until recreated. This keeps the data volume.
+
+```bash
+cd cozy_stack
+./compose-wrapper.sh up -d --force-recreate cozy-stack
+docker exec cozyt cozy-stack feature config --context default   # verify defaults loaded
+```
+
+If the config file was the only problem and no instances exist yet, you are done.
+
+### Layer 3: the data volume
+
+A re-render does *not* touch anything already written into CouchDB: created instances, their instance-level flags, global defaults set via `cozy-stack features defaults`, and any per-app URLs baked in by the patcher (these may carry an empty `BASE_DOMAIN`, e.g. domains like `user1.` or URLs like `https://linshare./new/`).
+
+Surgical (keep good instances, remove bad ones):
+
+```bash
+docker exec cozyt cozy-stack instances ls
+docker exec cozyt cozy-stack instances rm --force user1.
+docker exec cozyt cozy-stack feature flags --domain user1.${BASE_DOMAIN} '{"apps.hidden": null}'
+```
+
+Nuclear (clean slate, destroys all cozy instances and their files):
+
+```bash
+cd cozy_stack
+./compose-wrapper.sh down
+docker volume rm cozy_stack_cozy-data
+./compose-wrapper.sh up -d        # re-renders automatically, recreates instances
+```
+
+`docker volume rm cozy_stack_cozy-data` is irreversible and wipes every user's drive in that cozy. Fine on a POC; never run it on a deployment with real data. Always bring the stack up through `./wrapper.sh up` or `cozy_stack/compose-wrapper.sh up`, never a bare `docker compose up` at the repo root, or the unrendered-config bug comes back.


### PR DESCRIPTION
## Summary

### Context
The rendered `cozy.yaml` is gitignored and bind-mounted into the container verbatim, so whatever sits on disk is what cozy-stack runs. It is only generated by `compose-wrapper.sh`, which means a half-rendered or stale file can silently reach the stack: leftover `__DEFAULT_` markers make cozy-stack fail to parse the config, and an empty `BASE_DOMAIN` (when `.env` was not loaded) renders valid-but-wrong OIDC URLs like `https://auth./` that only surface later as broken login. A bare `docker compose up` at the repo root skips the wrapper entirely, so nothing was catching any of this.

### Solution
Fail fast at both layers where a bad config can enter, and document recovery.

### What changed
- `compose-wrapper.sh` aborts the render (and removes the file) if the result still has `__DEFAULT_` markers, a literal `${BASE_DOMAIN}`, or an empty-domain URL.
- `docker-entrypoint.sh` refuses to start cozy-stack when `cozy.yaml` is missing or carries any of those same defects, closing the wrapper-bypass path.
- Added a guide for resetting a polluted stack across the config file, the running container, and the data volume.