### PR TITLE
fix: send cozy mail through the bundled tmail SMTP server

### DIFF
--- a/cozy_stack/config/cozy.yaml.template
+++ b/cozy_stack/config/cozy.yaml.template
@@ -243,9 +243,9 @@ mail:
   noreply_name: My Twake
   reply_to: support@example.org
   # mail smtp host - flags: --mail-host
-  host: smtp.home
+  host: tmail-backend
   # mail smtp port - flags: --mail-port
-  port: 587
+  port: 25
   # mail smtp username - flags: --mail-username
   username: {{.Env.COZY_MAIL_USERNAME}}
   # mail smtp password - flags: --mail-password
@@ -257,9 +257,9 @@ mail:
   # disable mail STARTTLS
   # Means using plain unencrypted SMTP
   # flags: --mail-disable-tls
-  disable_tls: false
+  disable_tls: true
   # skip the certificate validation (may be useful on localhost)
-  skip_certificate_validation: false
+  skip_certificate_validation: true
   # Local Name
   # The hostname sent to the SMTP server with the HELO command
   # Defaults to localhost
@@ -279,10 +279,10 @@ mail:
 campaign_mail:
   # SMTP server host
   # Defaults to empty string
-  host: smtp.home
+  host: tmail-backend
   # SMTP server port
   # Defaults to 25
-  port: 587
+  port: 25
   # SMTP server username
   # Defaults to empty string
   username: {{.Env.COZY_MAIL_USERNAME}}
@@ -296,10 +296,10 @@ campaign_mail:
   # Disable STARTTLS for SMTP server
   # Means using plain unencrypted SMTP
   # Defaults to true
-  disable_tls: false
+  disable_tls: true
   # Skip the certificate validation (may be useful on localhost)
   # Defaults to false
-  skip_certificate_validation: false
+  skip_certificate_validation: true
   # Local Name
   # The hostname sent to the SMTP server with the HELO command
   # Defaults to empty string


### PR DESCRIPTION
## Summary

The cozy `mail` and `campaign_mail` blocks pointed at `smtp.home`, a host that does not exist in the stack, so every mail send failed with a DNS lookup error and sharing invitation emails were never delivered. Point both at the `tmail-backend` James server that is already part of the stack, over plain SMTP on port 25 for in-network delivery.

### Why TLS is disabled

Port 25 on James is the plain SMTP listener: it offers neither implicit TLS (SMTPS) nor a STARTTLS chain that cozy would trust on this port. `use_ssl: true` would fail the handshake (port 25 is not TLS from the first byte), and `disable_tls: false` (STARTTLS) would fail to negotiate or hit a certificate validation error against the internal cert. Disabling both matches the listener cozy is actually talking to.

This hop is container to container inside the docker network and never leaves the host, the same trust boundary as the cozy to couchdb connection, so plaintext here carries no external exposure. A deployment relaying through an external SMTP provider instead would use port 587 with STARTTLS or 465 with SMTPS, real credentials, and a trusted certificate.
