### PR TITLE
fix: use absolute path for konnectors cmd so mail HTML renders

### DIFF
--- a/cozy_stack/config/cozy.yaml.template
+++ b/cozy_stack/config/cozy.yaml.template
@@ -220,7 +220,7 @@ jobs:
 
 # konnectors execution parameters for executing external processes.
 konnectors:
-  cmd: ./scripts/konnector-node-run.sh # run connectors with node
+  cmd: /usr/local/bin/konnector-node-run.sh # run connectors with node
   # cmd: ./scripts/konnector-node-run.sh # run connectors with node in dev mode
   # cmd: ./scripts/konnector-rkt-run.sh # run connectors with rkt
   # cmd: ./scripts/konnector-nsjail-node8-run.sh # run connectors with nsjail


### PR DESCRIPTION
## Summary

cozy-stack runs the configured konnectors command, which is also what renders mail HTML through cozy-mjml, from its working directory `/var/lib/cozy`. The relative `./scripts/konnector-node-run.sh` does not resolve there, so every mail send failed at the HTML rendering step. Point `konnectors.cmd` at the absolute path of the script shipped in the image.