### PR TITLE
fix: gate onlyoffice startup on postgres and rabbitmq health

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -31,8 +31,15 @@ STOP_ORDER=("tmail_app" "chat_app" "calendar_app" "meet_app" "onlyoffice_app" "c
 #   - meet_app: confidential client (visio) — exchanges code with client_secret server-side.
 #   - tmail_app, calendar_app: public clients with lazy introspection, gated as a
 #     precaution so the first login is never racing the IdP startup.
+# onlyoffice_app gated on its backing services (both live in twake_db, so they
+# cannot be expressed as a compose depends_on):
+#   - postgres: documentserver stores document/task state there and runs its
+#     schema setup at boot.
+#   - rabbitmq: documentserver uses AMQP for its converter queues and
+#     restart-loops while it is unreachable.
 declare -A REPO_DEPS
 REPO_DEPS=(
+    ["onlyoffice_app"]="postgres rabbitmq"
     ["chat_app"]="lemonldap-ng"
     ["cozy_stack"]="lemonldap-ng"
     ["meet_app"]="lemonldap-ng"


### PR DESCRIPTION
## Context

OnlyOffice documentserver reaches Postgres (its database) and RabbitMQ (its AMQP converter queues) at boot. Both live in the `twake_db` compose project, so OnlyOffice cannot express them as a compose `depends_on`. The wrapper had no cross-project gate for `onlyoffice_app`, so starting it raced those services: the container logged `the database system is starting up` and restart-looped until they came up, which on a slow boot outlasts the wrapper's health wait and surfaces as a failed OnlyOffice health check.

## Solution

Add a `REPO_DEPS` entry gating `onlyoffice_app` on `postgres` and `rabbitmq` being healthy before it starts, the same mechanism already used to gate apps on lemonldap-ng. The wrapper now refuses to start OnlyOffice until both backing services report healthy.

closes https://github.com/linagora/twake-workplace-docker/issues/55