### PR TITLE
fix: pull published tom and fed images instead of building

### DIFF
--- a/chat_app/docker-compose.yaml
+++ b/chat_app/docker-compose.yaml
@@ -39,11 +39,11 @@ services:
       - "traefik.http.routers.matrixfromchat.priority=100"
 
   tom:
-    image: tom
-    build:
-      context: .
-      # dockerfile: ./packages/tom-server/Dockerfile
-      dockerfile: Dockerfile
+    image: linagora/tom-server:v2026-04-30
+    # To build from source instead of pulling the published image, uncomment:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
       synapse:
@@ -124,14 +124,15 @@ services:
       - "traefik.http.routers.tomfromchat.priority=100" 
 
   fed:
-    image: fed
+    image: linagora/tom-federated-identity-service:v2026-04-15
     restart: unless-stopped
     depends_on:
       tom:
         condition: service_started
-    build:
-      context:  ./
-      dockerfile: packages/federated-identity-service/Dockerfile
+    # To build from source instead of pulling the published image, uncomment:
+    # build:
+    #   context:  ./
+    #   dockerfile: packages/federated-identity-service/Dockerfile
     # ports:
     #   - 3001:3001
     #   - 9229:9229


### PR DESCRIPTION
## Problem

The `tom` and `fed` services in `chat_app/docker-compose.yaml` used bare image names (`image: tom`, `image: fed`) alongside active `build:` blocks. A bare name resolves to `docker.io/library/tom`, so on `up` Docker tries to pull and authenticate against a registry image that does not exist, then falls back to a slow local source build that requires the entire `tom-server` workspace. On a fresh install this surfaces as a confusing login error followed by a long build.

## Solution

Point both services at their published Docker Hub images so they pull right away:

- `tom` -> `linagora/tom-server:v2026-04-30`
- `fed` -> `linagora/tom-federated-identity-service:v2026-04-15`

Tags are pinned for reproducible installs, matching the convention used elsewhere in the stack (for example `synapse:v1.119.0`). The `build:` blocks are commented out rather than removed, so building from source stays one uncomment away for development.

closes #51 