### PR TITLE
feat: set ldap password when provisioning users via the cli

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -65,8 +65,20 @@ Per-field flags (only valid with positional `<userName>`):
 | `--phone VALUE` | Sets `phoneNumbers[0].value` (`primary: true`) |
 | `--locale VALUE` | Sets `preferredLanguage` |
 | `--title VALUE` | Sets `title` |
+| `--password VALUE` | Sets the SCIM `password`, written to LDAP `userPassword` (see below) |
 | `--inactive` | Sets `active: false` (default is `true`) |
-| `--dry-run` | Print SCIM body for each entry without POSTing |
+| `--dry-run` | Print SCIM body for each entry (password masked as `***`) without POSTing |
+
+#### Passwords and login
+
+Whether a user needs a password depends on `AUTH_MODE` (set in `.env`):
+
+- **`LDAP`** (default): LemonLDAP authenticates by binding against the directory, so an account with no `userPassword` **cannot log in**. Pass `--password` (or a top-level `password` in file mode) so the user can authenticate. `users add` prints a warning when no password is given in this mode.
+- **`OpenIDConnect`**: the external IdP owns credentials and the LDAP password is ignored. `users add` warns if you pass one.
+
+For this to work, ldap-rest maps the SCIM `password` to LDAP `userPassword` via `DM_SCIM_USER_MAPPING` (wired in `twake_auth/docker-compose.yml`); without that mapping the default SCIM schema silently drops the field. The bootstrapped demo users (`user1`…`user3`) already carry passwords.
+
+> **Security caveat.** This slapd stores `userPassword` in **cleartext** (it does not hash on write), and the mapping is **bidirectional**: `GET /scim/v2/Users` returns the stored `password`, so anyone holding `LDAP_REST_ADMIN_TOKEN` can read every user's password, and `slapcat`/LDAP backups contain them in the clear. `users list` does not print passwords, but it does fetch them. Treat the admin token and LDAP data volume as secrets. Do not reuse a real/shared password here.
 
 Exit 0 if every POST returned 2xx, 1 otherwise.
 

--- a/docs/scim-import.md
+++ b/docs/scim-import.md
@@ -25,6 +25,14 @@ Each entry needs a valid `userName`, given/family name, and email. The `userName
 
 `userName` must be a valid DNS label: lowercase letters, digits, hyphens, no leading or trailing hyphen, ≤63 chars. The script rejects the whole batch if any entry fails this check.
 
+**Passwords (LDAP mode only).** When `AUTH_MODE=LDAP` (the default), LemonLDAP authenticates against the directory, so each user needs a password or they cannot log in. Add a top-level `password` to each entry:
+
+```json
+{ "userName": "alice", "givenName": "Alice", "familyName": "DURAND", "email": "alice@example.org", "password": "Alice@Init123" }
+```
+
+(or, for a single positional user, `users add alice --password '…'`). `users add` warns for any entry created without a password in LDAP mode. Under `AUTH_MODE=OpenIDConnect` the IdP owns credentials and the password is ignored (and warned about). See the security caveat in [CLI.md](CLI.md#passwords-and-login): the password is stored and returned in cleartext, so use a throwaway initial value, not a real one.
+
 ## 2. Run the import
 
 ```bash
@@ -93,9 +101,15 @@ docker exec rabbitmq rabbitmqctl list_queues name messages consumers \
 
 `messages` should be 0 and `consumers` ≥ 1. Anything in `auth.dlq` is a hard failure: the message landed in the dead-letter queue after exhausting retries.
 
-## 4. Login flow (when AUTH_MODE=OpenIDConnect)
+## 4. Login flow
 
-Open `https://<userName>.<BASE_DOMAIN>` in an incognito window. The flow is OP login → LemonLDAP callback → cozy redirect → instance home. If you see "Error during authentication with OpenID Provider", read [external-oidc.md](external-oidc.md).
+Open `https://<userName>-home.<BASE_DOMAIN>` (or `https://<userName>.<BASE_DOMAIN>`) in an incognito window.
+
+**`AUTH_MODE=LDAP` (default).** cozy redirects to the LemonLDAP portal; log in with the `userName` and the `password` you set at import. LemonLDAP binds against LDAP, so a user imported without a password is rejected here (`Wrong credentials`). The flow is portal login → cozy OIDC callback → instance home.
+
+**`AUTH_MODE=OpenIDConnect`.** The flow is OP login → LemonLDAP callback → cozy redirect → instance home. If you see "Error during authentication with OpenID Provider", read [external-oidc.md](external-oidc.md).
+
+A successful login lands on the instance home (`<userName>-home.<BASE_DOMAIN>`). Note the home subdomain must resolve to the stack: deployments rely on wildcard DNS for `*.<BASE_DOMAIN>`; a local-only run with explicit `/etc/hosts` entries needs the `<userName>-home`/`-drive`/`-settings`/… subdomains added too.
 
 ## Cleanup
 

--- a/scripts/twake
+++ b/scripts/twake
@@ -56,6 +56,7 @@ fi
 # Diagnostics
 # -----------------------------------------------------------------------------
 err()  { printf '%s%s%s %s\n' "$C_RED" "$G_FAIL" "$C_END" "$*" >&2; }
+warn() { printf '%s%s%s %s\n' "$C_YELLOW" "$G_WARN" "$C_END" "$*" >&2; }
 die()  { err "$*"; exit 1; }
 
 # Verifies every named tool is on PATH; reports them all in one message,
@@ -336,7 +337,15 @@ ${C_DIM}Per-field flags${C_END} (only valid with positional userName):
   ${C_CYAN}--phone${C_END} VALUE
   ${C_CYAN}--locale${C_END} VALUE
   ${C_CYAN}--title${C_END} VALUE
+  ${C_CYAN}--password${C_END} VALUE          initial LDAP password (urn ...:User \`password\`)
   ${C_CYAN}--inactive${C_END}               sets active=false (default is active=true)
+
+${C_DIM}Passwords:${C_END} In file mode, add a top-level \`password\` to any entry. Whether a
+password is needed depends on ${C_CYAN}AUTH_MODE${C_END}:
+  ${G_BULLET} ${C_BOLD}LDAP${C_END} (default): LemonLDAP binds against the LDAP backend, so an account
+    with no password cannot log in. \`add\` warns when no password is given.
+  ${G_BULLET} ${C_BOLD}OpenIDConnect${C_END}: the external IdP owns credentials; any LDAP password is
+    ignored. \`add\` warns when a password is given.
 
 ${C_DIM}Modifiers:${C_END}
   ${C_CYAN}--dry-run${C_END}                print the SCIM body for each entry without POSTing
@@ -353,7 +362,7 @@ EOF
 cmd_users_add() {
   local pos_username="" file=""
   local email="" display_name="" given_name="" family_name=""
-  local phone="" locale="" title="" active=""
+  local phone="" locale="" title="" active="" password=""
   local dry_run=0
 
   while (( $# )); do
@@ -366,6 +375,7 @@ cmd_users_add() {
       --phone)        require_value "$@"; phone="$REQ_VAL";        shift 2 ;;
       --locale)       require_value "$@"; locale="$REQ_VAL";       shift 2 ;;
       --title)        require_value "$@"; title="$REQ_VAL";        shift 2 ;;
+      --password)     require_value "$@"; password="$REQ_VAL";     shift 2 ;;
       --inactive)     active="false";                              shift ;;
       --dry-run)      dry_run=1;                                   shift ;;
       -h|--help)      cmd_users_add_help; return 0 ;;
@@ -379,7 +389,7 @@ cmd_users_add() {
   if [[ -n "$file" && -n "$pos_username" ]]; then
     err "--file and a positional userName are mutually exclusive"; return 2
   fi
-  if [[ -n "$file" && -n "${email}${display_name}${given_name}${family_name}${phone}${locale}${title}${active}" ]]; then
+  if [[ -n "$file" && -n "${email}${display_name}${given_name}${family_name}${phone}${locale}${title}${active}${password}" ]]; then
     err "--file cannot be combined with per-field flags"; return 2
   fi
   if [[ -z "$file" && -z "$pos_username" ]]; then
@@ -407,6 +417,7 @@ cmd_users_add() {
       --arg locale      "$locale" \
       --arg title       "$title" \
       --arg active      "$active" \
+      --arg password    "$password" \
       '
         { userName: $userName }
         + (if $email       != "" then { email:        $email }       else {} end)
@@ -417,6 +428,7 @@ cmd_users_add() {
         + (if $locale      != "" then { preferredLanguage: $locale } else {} end)
         + (if $phone       != "" then { phoneNumbers: [{ value: $phone, primary: true }] } else {} end)
         + (if $active      != "" then { active: ($active == "true") } else {} end)
+        + (if $password    != "" then { password:     $password }    else {} end)
         | [.]
       ')
   fi
@@ -454,12 +466,25 @@ cmd_users_add() {
   (( dry_run == 1 )) && printf '  %s(dry-run: no requests will be sent)%s\n' "$C_DIM" "$C_END"
   echo
 
-  local ok=0 fail=0 uname body tmp http
+  # AUTH_MODE drives whether an LDAP password is meaningful. LDAP (the
+  # default) binds against the directory, so a passwordless account cannot
+  # log in; OpenIDConnect delegates login to an external IdP and ignores it.
+  local auth_mode="${AUTH_MODE:-LDAP}"
+
+  local ok=0 fail=0 uname body tmp http has_pw
   while IFS=$'\t' read -r uname body; do
     [[ -z "$uname" ]] && continue
+
+    has_pw=$(jq -r 'has("password") and (.password // "") != ""' <<<"$body")
+    if [[ "$auth_mode" == "LDAP" && "$has_pw" == "false" ]]; then
+      warn "$uname: no password set; in LDAP auth mode this account cannot log in until one is set"
+    elif [[ "$auth_mode" == "OpenIDConnect" && "$has_pw" == "true" ]]; then
+      warn "$uname: password provided but AUTH_MODE=OpenIDConnect; the LDAP password is ignored (external IdP handles login)"
+    fi
+
     if (( dry_run == 1 )); then
       printf '  %s%s%s %s\n' "$C_DIM" "$G_BULLET" "$C_END" "$uname"
-      jq . <<<"$body" | sed 's/^/      /'
+      jq '(if has("password") then .password = "***" else . end)' <<<"$body" | sed 's/^/      /'
       continue
     fi
     tmp=$(mktemp)

--- a/twake_auth/config/scim-user-mapping.json
+++ b/twake_auth/config/scim-user-mapping.json
@@ -1,0 +1,5 @@
+{
+  "entries": [
+    { "scim": "password", "ldap": "userPassword" }
+  ]
+}

--- a/twake_auth/docker-compose.yml
+++ b/twake_auth/docker-compose.yml
@@ -86,6 +86,13 @@ services:
       DM_SCIM_USER_BASE: ou=users,${LDAP_BASE_DN}
       DM_SCIM_GROUP_BASE: ou=groups,${LDAP_BASE_DN}
 
+      # The default SCIM mapping has no password attribute, so a SCIM
+      # `password` is silently dropped and the LDAP entry is created with no
+      # userPassword — leaving LDAP-mode users unable to log in. This custom
+      # mapping writes SCIM `password` to LDAP `userPassword` so users
+      # provisioned via `scripts/twake users add --password` can authenticate.
+      DM_SCIM_USER_MAPPING: /app/config/scim-user-mapping.json
+
       # twake/cozyProvision — provisions cozy instances + publishes auth/b2b
       # lifecycle events on RabbitMQ. The cozy-stack admin API lives on its
       # private port (6060) on the `cozyt` container; rabbitmq + the auth
@@ -102,6 +109,8 @@ services:
       DM_COZY_CONTEXT_NAME: ${COZY_CONTEXT_NAME}
       DM_COZY_APPS: ${COZY_APPS}
       DM_RABBITMQ_URL: amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@rabbitmq:5672/
+    volumes:
+      - ./config/scim-user-mapping.json:/app/config/scim-user-mapping.json:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ldap-rest.rule=Host(`ldap-rest.${BASE_DOMAIN}`)"


### PR DESCRIPTION
## Context

`users add` provisions users over SCIM but never set a password. In LDAP auth mode (the default), LemonLDAP authenticates by binding against the directory, so a user provisioned this way has no `userPassword` and cannot log in. External OIDC users are unaffected since the IdP owns credentials.

## Solution

Add a `--password` flag (and a top-level `password` in file mode), and map the SCIM `password` to LDAP `userPassword` in ldap-rest via `DM_SCIM_USER_MAPPING`, which the default SCIM schema otherwise silently drops. `users add` now warns when no password is given in LDAP mode, and when one is given under OpenIDConnect where it is ignored.

## Worth knowing

This slapd stores `userPassword` in cleartext and the SCIM mapping is bidirectional, so `GET /scim/v2/Users` returns the password and anyone holding the admin token can read it. Use throwaway initial passwords here, not real ones. This trade-off is documented in `docs/CLI.md`.