### PR TITLE
fix(calendar_app): bump esn-sabre sabre-4_7_0-09-01-2026 → 2.4.4.3

### DIFF
--- a/calendar_app/docker-compose.yml
+++ b/calendar_app/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - "traefik.http.services.feaccount.loadbalancer.server.port=80"
 
   sabre_dav:
-    image: linagora/esn-sabre:sabre-4_7_0-09-01-2026
+    image: linagora/esn-sabre:2.4.4.3
     container_name: sabre_dav
     platform: linux/amd64
     hostname: sabre-dav.${BASE_DOMAIN}


### PR DESCRIPTION
## Summary

`linagora/esn-sabre` is the DAV/CalDAV storage backend behind the Twake Calendar side-service. It's still an active upstream (weekly releases), despite the "esn-" name prefix — not to be confused with the abandoned `linagora/sabre-dav` fruux fork.

The pinned tag `sabre-4_7_0-09-01-2026` is a January 2026 build; the project has published 12 releases since (bug fixes on the CalDAV scheduling engine, iTIP replies, admin API…).

## Change

One line in `calendar_app/docker-compose.yml`, `sabre-4_7_0-09-01-2026` → `2.4.4.3` (the latest SemVer release on Docker Hub as of writing, 2026-07-29).

## Compatibility

- Container reads the same `ESN_MONGO_URI` / `SABRE_MONGO_URI` / `ESN_HOST` env
- sabre-dav stores state in Mongo (no local volume) → recreate is safe, no data migration
- `branch-master` is more recent still (2026-07-30) but moving; ping if you'd prefer that.

## Test plan

- [ ] `wrapper.sh up --calendar` boots sabre_dav on the new tag
- [ ] First OIDC login into Twake Calendar provisions the calendar-home correctly