### PR TITLE
fix(meet_app): bump livekit-server v1.8.3 → v1.13.4

### DIFF
--- a/meet_app/Dockerfile.livekit
+++ b/meet_app/Dockerfile.livekit
@@ -1,4 +1,4 @@
-FROM livekit/livekit-server:v1.8.3
+FROM livekit/livekit-server:v1.13.4
 USER root
 
 # install curl for healthcheck


### PR DESCRIPTION
## Summary

The Twake Meet frontend ships livekit-client SDK 2.19.2, which handshakes the room by calling `POST /rtc/v1/validate` on livekit-server. That endpoint was introduced in livekit-server v1.9. On the currently pinned v1.8.3 image it returns 404, the SDK raises `NegotiationError`, and the browser reconnects every ~15 s in a loop that never converges.

Observed in the browser as: the meeting joins, video/audio never negotiate, "reconnecting…" banner cycles.

## Change

One line in `meet_app/Dockerfile.livekit`: `FROM livekit/livekit-server:v1.8.3` → `v1.13.4`.

`livekit.yaml` is compatible; no config change required.

## Test plan

- [ ] `wrapper.sh up --meet` builds and boots livekit on v1.13.4
- [ ] Two-participant meeting reaches audio/video quickly, no reconnect loop after ~30s