### PR TITLE
fix: pin Django to 5.1.9 in meet_app to match djangorestframework

### DIFF
--- a/meet_app/Dockerfile
+++ b/meet_app/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir \
     drf-spectacular \
     drf-spectacular-sidecar \
     django-filter \
-    django-cors-headers
+    django-cors-headers \
+    "Django==5.1.9"
 
 USER 1000


### PR DESCRIPTION
### Steps to reproduce
1. Clone the repo, follow the README local setup (docker network, /etc/hosts, CA trust)
2. `./wrapper.sh up --full -d` (or `--meet`)
3. Observe `visio-backend` restart-looping

### Expected behavior
`visio-backend` starts and becomes healthy.

### Actual behavior
Container crash-loops with:
ImportError: cannot import name 'cc_delim_re' from 'django.utils.cache'

### Root cause
`meet_app/Dockerfile` does an unpinned `pip install django-extensions drf-spectacular drf-spectacular-sidecar django-filter django-cors-headers` on top of the base image `ghcr.io/cozy/meet-backend:0.0.1`. That base image ships `Django==5.1.9` + `djangorestframework==3.15.2`, the exact pair the `meet` package (0.1.22) requires (`pip show meet` confirms both `==` pins). 
The unpinned install lets pip drift Django to whatever is latest (6.1 at test time), which removed `django.utils.cache.cc_delim_re`  still imported by djangorestframework 3.15.2.

### Environment
- OS: Linux Mint 22.1
- Docker: 29.6.0
- Docker Compose: v5.2.0
- Repo commit: 1f49827