### PR TITLE
patch-cozy.sh: two typos break existing-instance detection and cozy-stack path

### DIFF
--- a/cozy_stack/scripts/patch-cozy.sh
+++ b/cozy_stack/scripts/patch-cozy.sh
@@ -22,7 +22,7 @@ docker exec -i -e ENABLED_APPS="$ENABLE_APPS" "$CONTAINER" sh <<EOF
 set -e
 
 # Use full path to cozy-stack
-COZY_STACK="/usr/bin/cozy-stack"
+COZY_STACK="/usr/local/bin/cozy-stack"
 
 # Base apps that are always installed
 BASE_APPS="home,drive,settings"
@@ -38,7 +38,7 @@ fi
 echo "▶ Apps to install: \$APPS_LIST"
 
 echo "▶ Fetching existing instances..."
-EXISTING_INSTANCES=\$(\$COZY_STACKs instances ls | awk '{print \$1}')
+EXISTING_INSTANCES=\$(\$COZY_STACK instances ls | awk '{print \$1}')
 
 create_instance() {
   DOMAIN="\$1"


### PR DESCRIPTION
### Steps to reproduce
1. Start the full stack, let `patcher-cozy` run once (creates user1/2/3 instances)
2. Re-run patcher-cozy a second time (e.g. re-running `./wrapper.sh up --full -d`, or `docker compose up -d patcher-cozy` directly in `cozy_stack/`)

### Expected behavior
Second run detects the existing instances and skips recreation, only applying whatever else changed (optional apps, feature flags).

### Actual behavior
Second run tries to recreate every instance and fails:
```
Failed to create instance for domain user1.twake.local
Error: Conflict: Instance already exists
```

### Root cause
Two typos in `cozy_stack/scripts/patch-cozy.sh`:
1. `COZY_STACK="/usr/bin/cozy-stack"` : wrong path, the binary is at  `/usr/local/bin/cozy-stack` in the cozy-stack image.
2. `EXISTING_INSTANCES=\$(\$COZY_STACKs instances ls | awk '{print \$1}')` : stray trailing `s` on the variable name. It silently fails inside the `$(...)`  substitution (`sh: instances: not found`), so `EXISTING_INSTANCES` is always empty and `create_instance()` never detects an already-provisioned instance.

### Environment
- OS: Linux Mint 22.1
- Docker: 29.6.0
- Docker Compose: v5.2.0
- Repo commit: 1f49827